### PR TITLE
功能新增，支持rzsz以及克隆会话

### DIFF
--- a/Sources/RemoraApp/ContentViewActions.swift
+++ b/Sources/RemoraApp/ContentViewActions.swift
@@ -749,6 +749,25 @@ extension ContentView {
         hostCatalog.markConnected(hostID: host.id)
     }
 
+    func cloneSession(_ tabID: UUID) {
+        guard let tab = workspace.tab(id: tabID),
+              let runtime = runtimeForTab(tab),
+              let host = runtime.reconnectableSSHHost
+        else {
+            return
+        }
+
+        // Create a new tab and connect with the same host.
+        // SSH ControlMaster multiplexing will reuse the existing connection,
+        // so no password/2FA prompt is needed.
+        workspace.createTab(title: tab.title, connectLocalShell: false)
+        guard let newTabID = workspace.activeTabID else { return }
+        workspace.selectTab(newTabID)
+        workspace.connectActivePane(host: host, template: nil)
+        bootstrapFileManagerBindingForActiveRuntime()
+        hostCatalog.markConnected(hostID: host.id)
+    }
+
     func refreshOrReconnectFileManagerForActivePane() {
         guard let activeTabID = workspace.activeTabID,
               let runtime = workspace.activePane?.runtime

--- a/Sources/RemoraApp/ContentViewActions.swift
+++ b/Sources/RemoraApp/ContentViewActions.swift
@@ -758,8 +758,8 @@ extension ContentView {
         }
 
         // Create a new tab and connect with the same host.
-        // SSH ControlMaster multiplexing will reuse the existing connection,
-        // so no password/2FA prompt is needed.
+        // For key/agent auth: ControlMaster reuses the connection (no prompt).
+        // For password auth: sshpass auto-fills the stored password.
         workspace.createTab(title: tab.title, connectLocalShell: false)
         guard let newTabID = workspace.activeTabID else { return }
         workspace.selectTab(newTabID)

--- a/Sources/RemoraApp/ContentViewLayout.swift
+++ b/Sources/RemoraApp/ContentViewLayout.swift
@@ -740,6 +740,11 @@ extension ContentView {
             }
             .disabled(!canReconnectSSH)
 
+            contextMenuButton(tr("Clone Session"), systemImage: ContextMenuIconCatalog.cloneSession) {
+                cloneSession(tab.id)
+            }
+            .disabled(!canReconnectSSH)
+
             contextMenuButton(tr("Disconnect Session"), systemImage: ContextMenuIconCatalog.disconnect) {
                 disconnectSession(tab.id)
             }

--- a/Sources/RemoraApp/ContextMenuPresentation.swift
+++ b/Sources/RemoraApp/ContextMenuPresentation.swift
@@ -7,6 +7,7 @@ enum ContextMenuIconCatalog {
     static let splitHorizontal = "rectangle.split.2x1"
     static let splitVertical = "rectangle.split.1x2"
     static let reconnect = "arrow.clockwise"
+    static let cloneSession = "doc.on.doc.fill"
     static let disconnect = "xmark.circle"
     static let closeCurrent = "xmark"
     static let closeAll = "xmark.square"

--- a/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
@@ -564,3 +564,13 @@
 "menu.remora.new_ssh" = "New SSH Connection";
 "menu.remora.import" = "Import Connections";
 "menu.remora.export" = "Export Connections";
+
+/* ZMODEM */
+"ZMODEM Download" = "ZMODEM Download";
+"Save" = "Save";
+"ZMODEM Upload" = "ZMODEM Upload";
+"Upload" = "Upload";
+"ZMODEM Transfer" = "ZMODEM Transfer";
+"Receiving file…" = "Receiving file…";
+"Transfer complete" = "Transfer complete";
+"Cancel Transfer" = "Cancel Transfer";

--- a/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
@@ -574,3 +574,6 @@
 "Receiving file…" = "Receiving file…";
 "Transfer complete" = "Transfer complete";
 "Cancel Transfer" = "Cancel Transfer";
+
+/* Clone Session */
+"Clone Session" = "Clone Session";

--- a/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -571,3 +571,6 @@
 "Receiving file…" = "正在接收文件…";
 "Transfer complete" = "传输完成";
 "Cancel Transfer" = "取消传输";
+
+/* Clone Session */
+"Clone Session" = "克隆会话";

--- a/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -561,3 +561,13 @@
 "menu.remora.new_ssh" = "新建 SSH 连接";
 "menu.remora.import" = "导入连接";
 "menu.remora.export" = "导出连接";
+
+/* ZMODEM */
+"ZMODEM Download" = "ZMODEM 下载";
+"Save" = "保存";
+"ZMODEM Upload" = "ZMODEM 上传";
+"Upload" = "上传";
+"ZMODEM Transfer" = "ZMODEM 传输";
+"Receiving file…" = "正在接收文件…";
+"Transfer complete" = "传输完成";
+"Cancel Transfer" = "取消传输";

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -79,6 +79,10 @@ final class TerminalRuntime: ObservableObject {
     private var awaitingPwdResponse = false
     private var workingDirectoryLineBuffer = ""
 
+    // MARK: - ZMODEM
+    private var zmodemDetector = ZmodemDetector()
+    private(set) var zmodemCoordinator = ZmodemTransferCoordinator()
+
     private var isReconnecting = false
     init(
         localSessionManager: SessionManager = SessionManager(sshClientFactory: { LocalShellClient() }),
@@ -377,12 +381,53 @@ final class TerminalRuntime: ObservableObject {
 
     private func flushOutputBatch(_ data: Data) {
         guard !data.isEmpty else { return }
+
+        // ZMODEM: if transfer is active, route all data to engine
+        if zmodemCoordinator.isActive {
+            zmodemCoordinator.feedOutput(data)
+            return
+        }
+
+        // ZMODEM: detect initiation sequence
+        let result = zmodemDetector.feed(data)
+        if let trigger = result.trigger {
+            // Feed any normal data before the trigger to the terminal
+            if !result.passthrough.isEmpty {
+                appendTranscript(result.passthrough)
+                updateAuthenticationState(with: result.passthrough)
+                feedTerminalView(result.passthrough)
+            }
+            handleZmodemTrigger(trigger, trailingData: result.trailingData)
+            return
+        }
+
         appendTranscript(data)
         updateAuthenticationState(with: data)
+        feedTerminalView(data)
+    }
+
+    private func feedTerminalView(_ data: Data) {
         if let terminalView {
             terminalView.feed(data: data)
         } else {
             enqueuePendingOutput(data)
+        }
+    }
+
+    private func handleZmodemTrigger(_ trigger: ZmodemTrigger, trailingData: Data) {
+        let writer: (Data) async throws -> Void = { [weak self] data in
+            guard let self else { return }
+            let sid = await MainActor.run { self.sessionID }
+            let mgr = await MainActor.run { self.activeSessionManager }
+            guard let sid, let mgr else { return }
+            try await mgr.write(data, to: sid)
+        }
+
+        switch trigger {
+        case .download:
+            zmodemCoordinator.startReceive(initialData: trailingData, writer: writer)
+        case .upload:
+            zmodemCoordinator.startSend(initialData: trailingData, writer: writer)
         }
     }
 
@@ -461,6 +506,9 @@ final class TerminalRuntime: ObservableObject {
     }
 
     private func enqueueInput(_ data: Data, trackWorkingDirectory: Bool) {
+        // Block user input during ZMODEM transfer
+        if zmodemCoordinator.isActive { return }
+
         pendingInputs.append(.init(data: data, trackWorkingDirectory: trackWorkingDirectory))
         guard inputDrainerTask == nil else { return }
 
@@ -625,6 +673,10 @@ final class TerminalRuntime: ObservableObject {
         transcriptRefreshTask = nil
         awaitingPwdResponse = false
         workingDirectoryLineBuffer.removeAll(keepingCapacity: false)
+        zmodemDetector.reset()
+        if zmodemCoordinator.isActive {
+            zmodemCoordinator.cancelTransfer()
+        }
     }
 
     private func applyPendingResizeIfNeeded() async {

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -388,6 +388,12 @@ final class TerminalRuntime: ObservableObject {
             return
         }
 
+        // ZMODEM: reset detector after transfer ends to avoid re-triggering on leftover bytes
+        if zmodemCoordinator.finished {
+            zmodemDetector.reset()
+            zmodemCoordinator.finished = false
+        }
+
         // ZMODEM: detect initiation sequence
         let result = zmodemDetector.feed(data)
         if let trigger = result.trigger {

--- a/Sources/RemoraApp/ZmodemTransferCoordinator.swift
+++ b/Sources/RemoraApp/ZmodemTransferCoordinator.swift
@@ -1,0 +1,195 @@
+import Foundation
+import AppKit
+import RemoraCore
+
+// MARK: - ZMODEM Transfer Coordinator
+
+@MainActor
+final class ZmodemTransferCoordinator: ObservableObject {
+    @Published var isActive = false
+    @Published var fileName: String = ""
+    @Published var fileSize: Int64?
+    @Published var bytesTransferred: Int64 = 0
+    @Published var finished = false
+    @Published var errorMessage: String?
+
+    private var receiveEngine: ZmodemReceiveEngine?
+    private var sendEngine: ZmodemSendEngine?
+    private var writeToSession: ((Data) async throws -> Void)?
+
+    /// Serial write queue to guarantee ordering of protocol messages
+    private var pendingWrites: [Data] = []
+    private var isWriting = false
+
+    // MARK: - Receive (sz download)
+
+    func startReceive(initialData: Data, writer: @escaping (Data) async throws -> Void) {
+        resetState()
+        isActive = true
+        writeToSession = writer
+
+        let engine = ZmodemReceiveEngine { [weak self] event in
+            MainActor.assumeIsolated {
+                self?.handleEvent(event)
+            }
+        }
+        self.receiveEngine = engine
+        engine.feedOutput(initialData)
+    }
+
+    // MARK: - Send (rz upload)
+
+    func startSend(initialData: Data, writer: @escaping (Data) async throws -> Void) {
+        resetState()
+        isActive = true
+        writeToSession = writer
+
+        let engine = ZmodemSendEngine { [weak self] event in
+            MainActor.assumeIsolated {
+                self?.handleEvent(event)
+            }
+        }
+        self.sendEngine = engine
+
+        // Feed initial data — engine buffers in waitingForFiles state
+        engine.feedOutput(initialData)
+
+        presentOpenPanel { [weak self] urls in
+            guard let self, self.sendEngine === engine else { return }
+            if let urls, !urls.isEmpty {
+                engine.setFiles(urls)
+            } else {
+                self.cancelTransfer()
+            }
+        }
+    }
+
+    // MARK: - Common
+
+    func feedOutput(_ data: Data) {
+        receiveEngine?.feedOutput(data)
+        sendEngine?.feedOutput(data)
+    }
+
+    func cancelTransfer() {
+        receiveEngine?.cancel()
+        sendEngine?.cancel()
+        receiveEngine = nil
+        sendEngine = nil
+        if isActive {
+            isActive = false
+            finished = true
+        }
+    }
+
+    // MARK: - Event Handling
+
+    private func handleEvent(_ event: ZmodemEvent) {
+        switch event {
+        case .sendToRemote(let data):
+            enqueueWrite(data)
+
+        case .fileOffered(let name, let size):
+            fileName = name
+            fileSize = size
+            presentSavePanel(suggestedName: name)
+
+        case .progress(let progress):
+            fileName = progress.fileName
+            fileSize = progress.fileSize
+            bytesTransferred = progress.bytesTransferred
+
+        case .sessionFinished:
+            isActive = false
+            finished = true
+            receiveEngine = nil
+            sendEngine = nil
+            writeToSession = nil
+
+        case .error(let message):
+            errorMessage = message
+            isActive = false
+            receiveEngine = nil
+            sendEngine = nil
+            writeToSession = nil
+        }
+    }
+
+    // MARK: - Serial Write Queue
+
+    private func enqueueWrite(_ data: Data) {
+        pendingWrites.append(data)
+        NSLog("[ZmodemCoord] enqueueWrite: %d bytes, queue size=%d", data.count, pendingWrites.count)
+        drainWriteQueue()
+    }
+
+    private func drainWriteQueue() {
+        guard !isWriting, !pendingWrites.isEmpty, let writer = writeToSession else { return }
+        isWriting = true
+        NSLog("[ZmodemCoord] drainWriteQueue: starting, %d items", pendingWrites.count)
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            while !self.pendingWrites.isEmpty {
+                let data = self.pendingWrites.removeFirst()
+                NSLog("[ZmodemCoord] writing %d bytes to session", data.count)
+                try? await writer(data)
+            }
+            self.isWriting = false
+            NSLog("[ZmodemCoord] drainWriteQueue: done")
+        }
+    }
+
+    // MARK: - File Dialogs
+
+    private func presentSavePanel(suggestedName: String) {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = suggestedName
+        panel.canCreateDirectories = true
+        panel.title = tr("ZMODEM Download")
+        panel.prompt = tr("Save")
+
+        panel.begin { [weak self] response in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if response == .OK, let url = panel.url {
+                    self.receiveEngine?.acceptFile(saveTo: url)
+                } else {
+                    self.receiveEngine?.skipFile()
+                }
+            }
+        }
+    }
+
+    private func presentOpenPanel(completion: @escaping ([URL]?) -> Void) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.title = tr("ZMODEM Upload")
+        panel.prompt = tr("Upload")
+
+        panel.begin { response in
+            DispatchQueue.main.async {
+                if response == .OK {
+                    completion(panel.urls)
+                } else {
+                    completion(nil)
+                }
+            }
+        }
+    }
+
+    private func resetState() {
+        receiveEngine = nil
+        sendEngine = nil
+        writeToSession = nil
+        pendingWrites.removeAll()
+        isWriting = false
+        finished = false
+        errorMessage = nil
+        fileName = ""
+        fileSize = nil
+        bytesTransferred = 0
+    }
+}

--- a/Sources/RemoraApp/ZmodemTransferCoordinator.swift
+++ b/Sources/RemoraApp/ZmodemTransferCoordinator.swift
@@ -119,24 +119,20 @@ final class ZmodemTransferCoordinator: ObservableObject {
 
     private func enqueueWrite(_ data: Data) {
         pendingWrites.append(data)
-        NSLog("[ZmodemCoord] enqueueWrite: %d bytes, queue size=%d", data.count, pendingWrites.count)
         drainWriteQueue()
     }
 
     private func drainWriteQueue() {
         guard !isWriting, !pendingWrites.isEmpty, let writer = writeToSession else { return }
         isWriting = true
-        NSLog("[ZmodemCoord] drainWriteQueue: starting, %d items", pendingWrites.count)
 
         Task { @MainActor [weak self] in
             guard let self else { return }
             while !self.pendingWrites.isEmpty {
                 let data = self.pendingWrites.removeFirst()
-                NSLog("[ZmodemCoord] writing %d bytes to session", data.count)
                 try? await writer(data)
             }
             self.isWriting = false
-            NSLog("[ZmodemCoord] drainWriteQueue: done")
         }
     }
 

--- a/Sources/RemoraApp/ZmodemTransferCoordinator.swift
+++ b/Sources/RemoraApp/ZmodemTransferCoordinator.swift
@@ -50,8 +50,6 @@ final class ZmodemTransferCoordinator: ObservableObject {
             }
         }
         self.sendEngine = engine
-
-        // Feed initial data — engine buffers in waitingForFiles state
         engine.feedOutput(initialData)
 
         presentOpenPanel { [weak self] urls in
@@ -92,7 +90,7 @@ final class ZmodemTransferCoordinator: ObservableObject {
         case .fileOffered(let name, let size):
             fileName = name
             fileSize = size
-            presentSavePanel(suggestedName: name)
+            autoAcceptFile(name: name)
 
         case .progress(let progress):
             fileName = progress.fileName
@@ -113,6 +111,23 @@ final class ZmodemTransferCoordinator: ObservableObject {
             sendEngine = nil
             writeToSession = nil
         }
+    }
+
+    // MARK: - Auto-save to Download Directory
+
+    private func autoAcceptFile(name: String) {
+        let downloadDir = resolvedDownloadDirectory()
+        // Ensure directory exists
+        try? FileManager.default.createDirectory(at: downloadDir, withIntermediateDirectories: true)
+
+        let fileURL = downloadDir.appendingPathComponent(name)
+        // Overwrite existing file without asking
+        receiveEngine?.acceptFile(saveTo: fileURL)
+    }
+
+    private func resolvedDownloadDirectory() -> URL {
+        let storedPath = AppPreferences.shared.snapshot.downloadDirectoryPath
+        return AppSettings.resolvedDownloadDirectoryURL(from: storedPath)
     }
 
     // MARK: - Serial Write Queue
@@ -137,25 +152,6 @@ final class ZmodemTransferCoordinator: ObservableObject {
     }
 
     // MARK: - File Dialogs
-
-    private func presentSavePanel(suggestedName: String) {
-        let panel = NSSavePanel()
-        panel.nameFieldStringValue = suggestedName
-        panel.canCreateDirectories = true
-        panel.title = tr("ZMODEM Download")
-        panel.prompt = tr("Save")
-
-        panel.begin { [weak self] response in
-            DispatchQueue.main.async {
-                guard let self else { return }
-                if response == .OK, let url = panel.url {
-                    self.receiveEngine?.acceptFile(saveTo: url)
-                } else {
-                    self.receiveEngine?.skipFile()
-                }
-            }
-        }
-    }
 
     private func presentOpenPanel(completion: @escaping ([URL]?) -> Void) {
         let panel = NSOpenPanel()

--- a/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
+++ b/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
@@ -34,6 +34,8 @@ enum SSHConnectionReusePolicy {
         authMethod: AuthenticationMethod,
         hasStoredPassword: Bool
     ) -> Bool {
-        authMethod != .password || !hasStoredPassword
+        // Always enable connection reuse to support session cloning.
+        // ControlMaster is compatible with all auth methods including sshpass.
+        true
     }
 }

--- a/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
+++ b/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
@@ -16,6 +16,11 @@ enum SSHConnectionReuse {
         ]
     }
 
+    /// Check if a ControlMaster socket exists for this host
+    static func hasActiveSocket(for host: Host) -> Bool {
+        FileManager.default.fileExists(atPath: controlPath(for: host))
+    }
+
     static func controlPath(for host: Host) -> String {
         let raw = "remora-\(host.username)-\(host.address)-\(host.port)"
         let sanitized = raw.map { scalar -> Character in
@@ -34,8 +39,6 @@ enum SSHConnectionReusePolicy {
         authMethod: AuthenticationMethod,
         hasStoredPassword: Bool
     ) -> Bool {
-        // Always enable connection reuse to support session cloning.
-        // ControlMaster is compatible with all auth methods including sshpass.
-        true
+        authMethod != .password || !hasStoredPassword
     }
 }

--- a/Sources/RemoraCore/SSH/SystemSSHClient.swift
+++ b/Sources/RemoraCore/SSH/SystemSSHClient.swift
@@ -527,7 +527,7 @@ public final class ProcessSSHShellSession: SSHTransportSessionProtocol, @uncheck
             return LaunchPlan(
                 configuration: makeStandardLaunchConfiguration(
                     for: host,
-                    useConnectionReuse: false,
+                    useConnectionReuse: true,
                     compatibilityProfile: compatibilityProfile
                 ),
                 interactivePasswordAutofill: password
@@ -667,7 +667,7 @@ public final class ProcessSSHShellSession: SSHTransportSessionProtocol, @uncheck
         let wrapped = wrappedSSHLaunchConfiguration(
             sshArguments: makeSSHArguments(
                 for: host,
-                useConnectionReuse: false,
+                useConnectionReuse: true,
                 allocateTTY: allocateTTY,
                 remoteCommand: remoteCommand,
                 compatibilityProfile: compatibilityProfile

--- a/Sources/RemoraCore/SSH/SystemSSHClient.swift
+++ b/Sources/RemoraCore/SSH/SystemSSHClient.swift
@@ -561,6 +561,7 @@ public final class ProcessSSHShellSession: SSHTransportSessionProtocol, @uncheck
             "-o", "ServerAliveInterval=\(max(5, host.policies.keepAliveSeconds))",
             "-o", "ServerAliveCountMax=3",
             "-o", "StrictHostKeyChecking=ask",
+            "-o", "LogLevel=ERROR",
         ]
         if allocateTTY {
             args.insert("-tt", at: 0)
@@ -664,10 +665,29 @@ public final class ProcessSSHShellSession: SSHTransportSessionProtocol, @uncheck
         allocateTTY: Bool = true,
         compatibilityProfile: SSHCompatibilityProfile = SSHCompatibilityProfile()
     ) -> LaunchConfiguration? {
+        // When sshpass is available, enable ControlMaster for connection reuse (clone session).
+        // sshpass handles PTY internally so we skip the `script` wrapper to avoid
+        // interfering with ControlMaster socket lifecycle.
+        if let sshpassPath {
+            let sshArgs = makeSSHArguments(
+                for: host,
+                useConnectionReuse: true,
+                allocateTTY: allocateTTY,
+                remoteCommand: remoteCommand,
+                compatibilityProfile: compatibilityProfile
+            )
+            return LaunchConfiguration(
+                executablePath: sshpassPath,
+                arguments: ["-e", "/usr/bin/ssh"] + sshArgs,
+                environment: mergedTerminalEnvironment(["SSHPASS": password])
+            )
+        }
+
+        // Fallback: askpass (no ControlMaster — script wrapper interferes)
         let wrapped = wrappedSSHLaunchConfiguration(
             sshArguments: makeSSHArguments(
                 for: host,
-                useConnectionReuse: true,
+                useConnectionReuse: false,
                 allocateTTY: allocateTTY,
                 remoteCommand: remoteCommand,
                 compatibilityProfile: compatibilityProfile
@@ -675,14 +695,6 @@ public final class ProcessSSHShellSession: SSHTransportSessionProtocol, @uncheck
             environment: [:],
             wrapInScript: allocateTTY
         )
-
-        if let sshpassPath {
-            return LaunchConfiguration(
-                executablePath: sshpassPath,
-                arguments: ["-e", wrapped.executablePath] + wrapped.arguments,
-                environment: ["SSHPASS": password]
-            )
-        }
 
         guard let askPassScriptPath else { return nil }
         return LaunchConfiguration(

--- a/Sources/RemoraCore/ZModem/ZmodemConstants.swift
+++ b/Sources/RemoraCore/ZModem/ZmodemConstants.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// MARK: - ZMODEM Protocol Constants
+
+/// ZMODEM frame types
+public enum ZmodemFrameType: UInt8, Sendable {
+    case ZRQINIT  = 0   // Request receive init
+    case ZRINIT   = 1   // Receive init
+    case ZSINIT   = 2   // Send init sequence
+    case ZACK     = 3   // ACK
+    case ZFILE    = 4   // File name from sender
+    case ZSKIP    = 5   // Skip this file
+    case ZNAK     = 6   // Last packet was garbled
+    case ZABORT   = 7   // Abort batch transfers
+    case ZFIN     = 8   // Finish session
+    case ZRPOS    = 9   // Resume data trans at this position
+    case ZDATA    = 10  // Data packet(s) follow
+    case ZEOF     = 11  // End of file
+    case ZFERR    = 12  // Fatal read or write error
+    case ZCRC     = 13  // Request for file CRC and target position
+    case ZCHALLENGE = 14 // Receiver's challenge
+    case ZCOMPL   = 15  // Request is complete
+    case ZCAN     = 16  // Pseudo frame: other end cancelled with CAN*5
+    case ZFREECNT = 17  // Request for free bytes on filesystem
+    case ZCOMMAND = 18  // Command from sending program
+    case ZSTDERR  = 19  // Output to standard error
+}
+
+/// ZMODEM data sub-packet types
+public enum ZmodemSubPacketType: UInt8, Sendable {
+    case ZCRCE = 0x68  // 'h' - CRC next, frame ends, header follows
+    case ZCRCG = 0x69  // 'i' - CRC next, frame continues nonstop
+    case ZCRCQ = 0x6A  // 'j' - CRC next, frame continues, ZACK expected
+    case ZCRCW = 0x6B  // 'k' - CRC next, frame ends, ZACK expected
+}
+
+/// ZMODEM encoding types
+public enum ZmodemHeaderEncoding: UInt8, Sendable {
+    case ZBIN   = 0x41  // 'A' - Binary header with 16-bit CRC
+    case ZHEX   = 0x42  // 'B' - Hex header with 16-bit CRC
+    case ZBIN32 = 0x43  // 'C' - Binary header with 32-bit CRC
+}
+
+/// ZMODEM special bytes
+public enum ZmodemByte {
+    public static let ZPAD: UInt8  = 0x2A  // '*' - Padding character
+    public static let ZDLE: UInt8  = 0x18  // CAN - ZMODEM escape character
+    public static let ZDLEE: UInt8 = 0x58  // 'X' - Escaped ZDLE
+    public static let XON: UInt8   = 0x11
+    public static let XOFF: UInt8  = 0x13
+    public static let CR: UInt8    = 0x0D
+    public static let LF: UInt8    = 0x0A
+}
+
+/// ZRINIT capability flags (ZF0)
+public struct ZmodemRInitFlags: OptionSet, Sendable {
+    public let rawValue: UInt8
+    public init(rawValue: UInt8) { self.rawValue = rawValue }
+
+    public static let canFDX  = ZmodemRInitFlags(rawValue: 0x01) // Rx can send and receive true FDX
+    public static let canOVIO = ZmodemRInitFlags(rawValue: 0x02) // Rx can receive data during disk I/O
+    public static let canBRK  = ZmodemRInitFlags(rawValue: 0x04) // Rx can send a break signal
+    public static let canCRY  = ZmodemRInitFlags(rawValue: 0x08) // Receiver can decrypt
+    public static let canLZW  = ZmodemRInitFlags(rawValue: 0x10) // Receiver can uncompress
+    public static let canFC32 = ZmodemRInitFlags(rawValue: 0x20) // Rx can use 32 bit Frame Check
+    public static let escCtl  = ZmodemRInitFlags(rawValue: 0x40) // Receiver expects ctl chars to be escaped
+}
+
+/// ZMODEM trigger detection signature
+/// sz sends: "rz\r**\x18B00..." (ZRQINIT)
+/// rz sends: "rz\r**\x18B01..." (ZRINIT, waiting for file)
+public enum ZmodemTrigger: Sendable {
+    case download  // Remote sz → client receives file
+    case upload    // Remote rz → client sends file
+}
+
+/// ZMODEM CRC-16 (CCITT) lookup table
+public let zmodemCRC16Table: [UInt16] = {
+    var table = [UInt16](repeating: 0, count: 256)
+    for i in 0..<256 {
+        var crc = UInt16(i) << 8
+        for _ in 0..<8 {
+            if crc & 0x8000 != 0 {
+                crc = (crc << 1) ^ 0x1021
+            } else {
+                crc <<= 1
+            }
+        }
+        table[i] = crc
+    }
+    return table
+}()
+
+/// ZMODEM CRC-32 lookup table
+public let zmodemCRC32Table: [UInt32] = {
+    var table = [UInt32](repeating: 0, count: 256)
+    for i in 0..<256 {
+        var crc = UInt32(i)
+        for _ in 0..<8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB88320
+            } else {
+                crc >>= 1
+            }
+        }
+        table[i] = crc
+    }
+    return table
+}()
+
+public func zmodemCRC16(_ data: some Sequence<UInt8>, initial: UInt16 = 0) -> UInt16 {
+    var crc = initial
+    for byte in data {
+        let index = Int(((crc >> 8) ^ UInt16(byte)) & 0xFF)
+        crc = (crc << 8) ^ zmodemCRC16Table[index]
+    }
+    return crc
+}
+
+public func zmodemCRC32(_ data: some Sequence<UInt8>, initial: UInt32 = 0xFFFFFFFF) -> UInt32 {
+    var crc = initial
+    for byte in data {
+        let index = Int((crc ^ UInt32(byte)) & 0xFF)
+        crc = (crc >> 8) ^ zmodemCRC32Table[index]
+    }
+    return crc ^ 0xFFFFFFFF
+}

--- a/Sources/RemoraCore/ZModem/ZmodemDetector.swift
+++ b/Sources/RemoraCore/ZModem/ZmodemDetector.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+// MARK: - ZMODEM Stream Detector
+
+/// Result of feeding data through the ZMODEM detector
+public struct ZmodemDetectResult: Sendable {
+    /// Data that should pass through to the terminal normally
+    public let passthrough: Data
+    /// If non-nil, a ZMODEM session was detected
+    public let trigger: ZmodemTrigger?
+    /// Raw ZMODEM data that follows the trigger (includes the full header for engine parsing)
+    public let trailingData: Data
+
+    public init(passthrough: Data, trigger: ZmodemTrigger? = nil, trailingData: Data = Data()) {
+        self.passthrough = passthrough
+        self.trigger = trigger
+        self.trailingData = trailingData
+    }
+}
+
+/// Detects ZMODEM initiation sequences in a terminal output stream.
+///
+/// The detector looks for the pattern: `**\x18B` followed by `00` (ZRQINIT / sz download)
+/// or `01` (ZRINIT / rz upload).
+///
+/// This is designed to be fed chunks of data as they arrive from the PTY.
+/// It maintains a small tail buffer to handle the case where the magic sequence
+/// spans two consecutive chunks.
+public struct ZmodemDetector: Sendable {
+    /// The magic prefix: ** CAN B  (ZPAD ZPAD ZDLE ZHEX)
+    private static let magicPrefix: [UInt8] = [
+        ZmodemByte.ZPAD,  // '*'  0x2A
+        ZmodemByte.ZPAD,  // '*'  0x2A
+        ZmodemByte.ZDLE,  // CAN  0x18
+        ZmodemHeaderEncoding.ZHEX.rawValue, // 'B'  0x42
+    ]
+
+    /// We keep only the last few bytes to detect sequences that span chunk boundaries.
+    /// The magic sequence is 6 bytes ("**\x18B00"), so we keep 5 (prefix.count + 1)
+    /// to catch a split at any point.
+    private var tailBuffer: [UInt8] = []
+    private static let tailKeepSize = 5
+
+    public init() {}
+
+    /// Feed a chunk of output data. Returns detection result.
+    public mutating func feed(_ data: Data) -> ZmodemDetectResult {
+        guard !data.isEmpty else {
+            return ZmodemDetectResult(passthrough: data)
+        }
+
+        let bytes = Array(data)
+
+        // Combine tail from previous chunk with current data for boundary detection
+        let combined = tailBuffer + bytes
+        let tailLen = tailBuffer.count
+
+        // Search for magic prefix in combined buffer
+        if let matchResult = findMagicSequence(in: combined) {
+            let matchOffset = matchResult.offset
+
+            // Calculate how much of the original `data` is "before" the match
+            let passthroughFromData: Data
+            if matchOffset <= tailLen {
+                passthroughFromData = Data()
+            } else {
+                let dataOffset = matchOffset - tailLen
+                passthroughFromData = Data(bytes[0..<dataOffset])
+            }
+
+            // Trailing data includes the FULL header (starting from **\x18B...)
+            // so the engine can parse it properly
+            let trailingData: Data
+            if matchOffset < combined.count {
+                trailingData = Data(combined[matchOffset...])
+            } else {
+                trailingData = Data()
+            }
+
+            tailBuffer.removeAll()
+            return ZmodemDetectResult(
+                passthrough: passthroughFromData,
+                trigger: matchResult.trigger,
+                trailingData: trailingData
+            )
+        }
+
+        // No match found. Keep only the last few bytes as tail for next call.
+        let newTail: [UInt8]
+        if bytes.count >= Self.tailKeepSize {
+            newTail = Array(bytes.suffix(Self.tailKeepSize))
+        } else {
+            // Merge old tail + new bytes, keep last tailKeepSize
+            let merged = tailBuffer + bytes
+            newTail = Array(merged.suffix(Self.tailKeepSize))
+        }
+        tailBuffer = newTail
+
+        return ZmodemDetectResult(passthrough: data)
+    }
+
+    /// Reset detector state (e.g., after a transfer completes)
+    public mutating func reset() {
+        tailBuffer.removeAll()
+    }
+
+    // MARK: - Private
+
+    private struct MagicMatch {
+        let offset: Int
+        let trigger: ZmodemTrigger
+    }
+
+    private func findMagicSequence(in buffer: [UInt8]) -> MagicMatch? {
+        let prefix = Self.magicPrefix
+        // Need prefix (4 bytes) + 2 hex digits for frame type = 6 bytes minimum
+        guard buffer.count >= prefix.count + 2 else { return nil }
+
+        let searchEnd = buffer.count - prefix.count - 2
+        for i in 0...searchEnd {
+            guard buffer[i] == prefix[0],
+                  buffer[i + 1] == prefix[1],
+                  buffer[i + 2] == prefix[2],
+                  buffer[i + 3] == prefix[3]
+            else { continue }
+
+            let h1 = buffer[i + prefix.count]
+            let h2 = buffer[i + prefix.count + 1]
+
+            // "30 30" = ASCII '00' = ZRQINIT (sz download)
+            if h1 == 0x30, h2 == 0x30 {
+                return MagicMatch(offset: i, trigger: .download)
+            }
+            // "30 31" = ASCII '01' = ZRINIT (rz upload)
+            if h1 == 0x30, h2 == 0x31 {
+                return MagicMatch(offset: i, trigger: .upload)
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/RemoraCore/ZModem/ZmodemEngine.swift
+++ b/Sources/RemoraCore/ZModem/ZmodemEngine.swift
@@ -1,0 +1,443 @@
+import Foundation
+
+// MARK: - ZMODEM Receive Engine
+
+/// Transfer progress information
+public struct ZmodemProgress: Sendable {
+    public let fileName: String
+    public let fileSize: Int64?
+    public let bytesTransferred: Int64
+    public let finished: Bool
+    public let error: String?
+
+    public init(fileName: String, fileSize: Int64?, bytesTransferred: Int64, finished: Bool = false, error: String? = nil) {
+        self.fileName = fileName
+        self.fileSize = fileSize
+        self.bytesTransferred = bytesTransferred
+        self.finished = finished
+        self.error = error
+    }
+}
+
+/// Events emitted by the engine that the host must handle
+public enum ZmodemEvent: Sendable {
+    /// Engine needs to send data back to the remote (protocol responses)
+    case sendToRemote(Data)
+    /// A file is being offered; host should provide a file URL to save to
+    case fileOffered(name: String, size: Int64?)
+    /// Progress update
+    case progress(ZmodemProgress)
+    /// Transfer session finished (all files done or aborted)
+    case sessionFinished
+    /// An error occurred
+    case error(String)
+}
+
+/// ZMODEM receive state machine.
+///
+/// Usage:
+/// 1. Create engine, provide event handler
+/// 2. Feed initial trailing data from detector
+/// 3. Feed all subsequent PTY output data
+/// 4. When `fileOffered` event fires, call `acceptFile(saveTo:)` or `skipFile()`
+/// 5. Engine emits `sendToRemote` events — write that data to the PTY
+public final class ZmodemReceiveEngine: @unchecked Sendable {
+    public typealias EventHandler = @Sendable (ZmodemEvent) -> Void
+
+    private enum State {
+        case waitingForZRQINIT
+        case waitingForZFILE
+        case waitingForFileAccept
+        case receivingData
+        case waitingForZFIN
+        case finished
+    }
+
+    private var state: State = .waitingForZRQINIT
+    private var buffer = Data()
+    private var useCRC32 = true
+    private var insideDataFrame = false
+    private let onEvent: EventHandler
+
+    // Current file state
+    private var currentFileName: String = ""
+    private var currentFileSize: Int64?
+    private var currentFileHandle: FileHandle?
+    private var currentFileURL: URL?
+    private var bytesReceived: Int64 = 0
+
+    public var isActive: Bool {
+        state != .finished
+    }
+
+    public init(onEvent: @escaping EventHandler) {
+        self.onEvent = onEvent
+    }
+
+    /// Feed raw PTY output data into the engine
+    public func feedOutput(_ data: Data) {
+        guard isActive else { return }
+        buffer.append(data)
+
+        // Safety: prevent unbounded buffer growth
+        if buffer.count > 4 * 1024 * 1024 {
+            emit(.error("ZMODEM buffer overflow"))
+            cancel()
+            return
+        }
+
+        processBuffer()
+    }
+
+    /// Accept the offered file, saving to the given URL
+    public func acceptFile(saveTo url: URL) {
+        guard state == .waitingForFileAccept else { return }
+        currentFileURL = url
+        bytesReceived = 0
+
+        // Create/truncate the file
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        currentFileHandle = FileHandle(forWritingAtPath: url.path)
+
+        state = .receivingData
+
+        // Send ZRPOS at offset 0 to start receiving
+        let rpos = ZmodemHeader.withPosition(type: .ZRPOS, 0)
+        emit(.sendToRemote(zmodemEncodeHexHeader(rpos)))
+
+        // Process any buffered data
+        processBuffer()
+    }
+
+    /// Skip the offered file
+    public func skipFile() {
+        guard state == .waitingForFileAccept else { return }
+        state = .waitingForZFILE
+
+        let skip = ZmodemHeader(type: .ZSKIP)
+        emit(.sendToRemote(zmodemEncodeHexHeader(skip)))
+    }
+
+    /// Cancel the entire transfer
+    public func cancel() {
+        closeCurrentFile()
+        // Standard ZMODEM abort: 8x CAN + 8x BS
+        var abort: [UInt8] = []
+        for _ in 0..<8 { abort.append(ZmodemByte.ZDLE) } // CAN = 0x18
+        for _ in 0..<8 { abort.append(0x08) }            // BS
+        emit(.sendToRemote(Data(abort)))
+        state = .finished
+        emit(.sessionFinished)
+    }
+
+    // MARK: - State Machine
+
+    private func processBuffer() {
+        // Prevent re-entrancy
+        var iterations = 0
+        let maxIterations = 500
+
+        while !buffer.isEmpty, isActive, iterations < maxIterations {
+            iterations += 1
+            let consumed: Bool
+
+            switch state {
+            case .waitingForZRQINIT:
+                consumed = handleWaitingForZRQINIT()
+            case .waitingForZFILE:
+                consumed = handleWaitingForZFILE()
+            case .waitingForFileAccept:
+                consumed = false // Waiting for host to call acceptFile/skipFile
+            case .receivingData:
+                consumed = handleReceivingData()
+            case .waitingForZFIN:
+                consumed = handleWaitingForZFIN()
+            case .finished:
+                consumed = false
+            }
+
+            if !consumed { break }
+        }
+    }
+
+    private func handleWaitingForZRQINIT() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else { return false }
+        buffer.removeFirst(consumed)
+
+        if header.type == .ZRQINIT {
+            // Respond with ZRINIT
+            state = .waitingForZFILE
+            let flags = ZmodemRInitFlags([.canFC32, .canFDX, .canOVIO])
+            let rinit = ZmodemHeader(type: .ZRINIT, p0: flags.rawValue)
+            emit(.sendToRemote(zmodemEncodeHexHeader(rinit)))
+            return true
+        }
+
+        // Unexpected header, try to continue
+        return true
+    }
+
+    private func handleWaitingForZFILE() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else { return false }
+
+        if header.type == .ZFIN {
+            buffer.removeFirst(consumed)
+            // Session done, respond with ZFIN
+            let fin = ZmodemHeader(type: .ZFIN)
+            emit(.sendToRemote(zmodemEncodeHexHeader(fin)))
+            state = .finished
+            emit(.sessionFinished)
+            return true
+        }
+
+        if header.type == .ZFILE {
+            buffer.removeFirst(consumed)
+            // Parse the sub-packet containing filename and size
+            guard let (fileInfo, subType, subConsumed) = parseNextSubPacket() else {
+                // Need more data — put header info aside, wait for sub-packet
+                return false
+            }
+            buffer.removeFirst(subConsumed)
+            _ = subType
+
+            parseFileInfo(fileInfo)
+            state = .waitingForFileAccept
+            emit(.fileOffered(name: currentFileName, size: currentFileSize))
+            return true
+        }
+
+        if header.type == .ZSINIT {
+            buffer.removeFirst(consumed)
+            // Skip ZSINIT sub-packet data
+            if let (_, _, subConsumed) = parseNextSubPacket() {
+                buffer.removeFirst(subConsumed)
+            }
+            // ACK it
+            let ack = ZmodemHeader(type: .ZACK)
+            emit(.sendToRemote(zmodemEncodeHexHeader(ack)))
+            return true
+        }
+
+        // Skip unknown headers
+        buffer.removeFirst(consumed)
+        return true
+    }
+
+    private func handleReceivingData() -> Bool {
+        // If we're inside a ZDATA frame, consume sub-packets first
+        if insideDataFrame {
+            let consumed = consumeDataSubPackets()
+            if !consumed, !insideDataFrame {
+                // Frame ended (ZCRCE/ZCRCW), try parsing next header
+                return handleReceivingData()
+            }
+            return consumed
+        }
+
+        guard let (header, consumed) = parseNextHeader() else { return false }
+
+        if header.type == .ZDATA {
+            buffer.removeFirst(consumed)
+            insideDataFrame = true
+            return consumeDataSubPackets()
+        }
+
+        if header.type == .ZEOF {
+            buffer.removeFirst(consumed)
+            finishCurrentFile()
+            state = .waitingForZFILE
+
+            let flags = ZmodemRInitFlags([.canFC32, .canFDX, .canOVIO])
+            let rinit = ZmodemHeader(type: .ZRINIT, p0: flags.rawValue)
+            emit(.sendToRemote(zmodemEncodeHexHeader(rinit)))
+            return true
+        }
+
+        if header.type == .ZFIN {
+            buffer.removeFirst(consumed)
+            finishCurrentFile()
+            let fin = ZmodemHeader(type: .ZFIN)
+            emit(.sendToRemote(zmodemEncodeHexHeader(fin)))
+            state = .finished
+            emit(.sessionFinished)
+            return true
+        }
+
+        // Unexpected header during data receive
+        buffer.removeFirst(consumed)
+        return true
+    }
+
+    private func handleWaitingForZFIN() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else { return false }
+        buffer.removeFirst(consumed)
+
+        if header.type == .ZFIN {
+            let fin = ZmodemHeader(type: .ZFIN)
+            emit(.sendToRemote(zmodemEncodeHexHeader(fin)))
+            state = .finished
+            emit(.sessionFinished)
+        }
+        return true
+    }
+
+    // MARK: - Data Sub-packet Processing
+
+    private func consumeDataSubPackets() -> Bool {
+        var didConsume = false
+
+        while !buffer.isEmpty {
+            guard let (payload, subType, consumed) = parseNextSubPacket() else {
+                break
+            }
+            buffer.removeFirst(consumed)
+            didConsume = true
+
+            // Write payload to file
+            writeToFile(payload)
+
+            switch subType {
+            case .ZCRCG:
+                // More data coming, continue
+                continue
+            case .ZCRCQ:
+                // Sender wants ACK, send ZACK with current position
+                let ack = ZmodemHeader.withPosition(type: .ZACK, UInt32(bytesReceived))
+                emit(.sendToRemote(zmodemEncodeHexHeader(ack)))
+                continue
+            case .ZCRCE:
+                // End of frame, header follows
+                insideDataFrame = false
+                return true
+            case .ZCRCW:
+                // End of frame, sender waits for ACK
+                insideDataFrame = false
+                let ack = ZmodemHeader.withPosition(type: .ZACK, UInt32(bytesReceived))
+                emit(.sendToRemote(zmodemEncodeHexHeader(ack)))
+                return true
+            }
+        }
+
+        return didConsume
+    }
+
+    // MARK: - Header Parsing
+
+    private func parseNextHeader() -> (ZmodemHeader, Int)? {
+        let bytes = Array(buffer)
+        let slice = bytes[...]
+
+        // Look for ZPAD or ZDLE that starts a header
+        for i in slice.indices {
+            // Hex header: ZPAD ZPAD ZDLE ZHEX
+            if i + 3 < slice.endIndex,
+               slice[i] == ZmodemByte.ZPAD,
+               slice[i + 1] == ZmodemByte.ZPAD,
+               slice[i + 2] == ZmodemByte.ZDLE,
+               slice[i + 3] == ZmodemHeaderEncoding.ZHEX.rawValue
+            {
+                let headerStart = i + 4
+                guard headerStart < slice.endIndex else { return nil }
+                if let (header, hConsumed) = zmodemParseHexHeader(slice[headerStart...]) {
+                    return (header, headerStart + hConsumed - slice.startIndex)
+                }
+                return nil // Incomplete
+            }
+
+            // Binary header CRC-32: ZPAD ZDLE ZBIN32
+            if i + 2 < slice.endIndex,
+               slice[i] == ZmodemByte.ZPAD,
+               slice[i + 1] == ZmodemByte.ZDLE,
+               slice[i + 2] == ZmodemHeaderEncoding.ZBIN32.rawValue
+            {
+                let headerStart = i + 3
+                guard headerStart < slice.endIndex else { return nil }
+                if let (header, hConsumed) = zmodemParseBin32Header(slice[headerStart...]) {
+                    useCRC32 = true
+                    return (header, headerStart + hConsumed - slice.startIndex)
+                }
+                return nil
+            }
+
+            // Binary header CRC-16: ZPAD ZDLE ZBIN
+            if i + 2 < slice.endIndex,
+               slice[i] == ZmodemByte.ZPAD,
+               slice[i + 1] == ZmodemByte.ZDLE,
+               slice[i + 2] == ZmodemHeaderEncoding.ZBIN.rawValue
+            {
+                let headerStart = i + 3
+                guard headerStart < slice.endIndex else { return nil }
+                if let (header, hConsumed) = zmodemParseBinHeader(slice[headerStart...]) {
+                    useCRC32 = false
+                    return (header, headerStart + hConsumed - slice.startIndex)
+                }
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    private func parseNextSubPacket() -> (Data, ZmodemSubPacketType, Int)? {
+        let bytes = Array(buffer)
+        let slice = bytes[...]
+        if useCRC32 {
+            return zmodemParseSubPacket32(slice)
+        } else {
+            return zmodemParseSubPacket16(slice)
+        }
+    }
+
+    // MARK: - File I/O
+
+    private func parseFileInfo(_ data: Data) {
+        // ZMODEM file info format: "filename\0size modification_date ..."
+        // The filename is null-terminated, followed by optional space-separated metadata
+        let bytes = Array(data)
+        let nullIndex = bytes.firstIndex(of: 0) ?? bytes.endIndex
+        currentFileName = String(bytes: bytes[0..<nullIndex], encoding: .utf8) ?? "unknown"
+
+        // Parse size from metadata after null
+        currentFileSize = nil
+        if nullIndex + 1 < bytes.count {
+            let metaStart = nullIndex + 1
+            let metaBytes = bytes[metaStart...]
+            if let metaStr = String(bytes: metaBytes, encoding: .utf8) {
+                let parts = metaStr.split(separator: " ")
+                if let first = parts.first, let size = Int64(first) {
+                    currentFileSize = size
+                }
+            }
+        }
+    }
+
+    private func writeToFile(_ data: Data) {
+        guard !data.isEmpty else { return }
+        currentFileHandle?.write(data)
+        bytesReceived += Int64(data.count)
+        emit(.progress(ZmodemProgress(
+            fileName: currentFileName,
+            fileSize: currentFileSize,
+            bytesTransferred: bytesReceived
+        )))
+    }
+
+    private func finishCurrentFile() {
+        closeCurrentFile()
+        emit(.progress(ZmodemProgress(
+            fileName: currentFileName,
+            fileSize: currentFileSize,
+            bytesTransferred: bytesReceived,
+            finished: true
+        )))
+    }
+
+    private func closeCurrentFile() {
+        try? currentFileHandle?.close()
+        currentFileHandle = nil
+    }
+
+    private func emit(_ event: ZmodemEvent) {
+        onEvent(event)
+    }
+}

--- a/Sources/RemoraCore/ZModem/ZmodemFrame.swift
+++ b/Sources/RemoraCore/ZModem/ZmodemFrame.swift
@@ -1,0 +1,382 @@
+import Foundation
+
+// MARK: - ZMODEM Frame Construction & Parsing
+
+/// A parsed ZMODEM header
+public struct ZmodemHeader: Sendable, Equatable {
+    public let type: ZmodemFrameType
+    public let flags: (UInt8, UInt8, UInt8, UInt8) // ZF3, ZF2, ZF1, ZF0
+
+    public init(type: ZmodemFrameType, p0: UInt8 = 0, p1: UInt8 = 0, p2: UInt8 = 0, p3: UInt8 = 0) {
+        self.type = type
+        self.flags = (p3, p2, p1, p0)
+    }
+
+    /// Interpret flags as a 32-bit file offset / position
+    public var position: UInt32 {
+        UInt32(flags.3) | (UInt32(flags.2) << 8) | (UInt32(flags.1) << 16) | (UInt32(flags.0) << 24)
+    }
+
+    /// Create a header with a 32-bit position value
+    public static func withPosition(type: ZmodemFrameType, _ pos: UInt32) -> ZmodemHeader {
+        ZmodemHeader(
+            type: type,
+            p0: UInt8(pos & 0xFF),
+            p1: UInt8((pos >> 8) & 0xFF),
+            p2: UInt8((pos >> 16) & 0xFF),
+            p3: UInt8((pos >> 24) & 0xFF)
+        )
+    }
+
+    public static func == (lhs: ZmodemHeader, rhs: ZmodemHeader) -> Bool {
+        lhs.type == rhs.type
+            && lhs.flags.0 == rhs.flags.0
+            && lhs.flags.1 == rhs.flags.1
+            && lhs.flags.2 == rhs.flags.2
+            && lhs.flags.3 == rhs.flags.3
+    }
+}
+
+// MARK: - Hex Header Encoding
+
+/// Build a ZMODEM hex header: ZPAD ZPAD ZDLE ZHEX type[2] f0[2] f1[2] f2[2] f3[2] crc[4] CR LF XON
+public func zmodemEncodeHexHeader(_ header: ZmodemHeader) -> Data {
+    var bytes: [UInt8] = []
+    bytes.append(ZmodemByte.ZPAD)
+    bytes.append(ZmodemByte.ZPAD)
+    bytes.append(ZmodemByte.ZDLE)
+    bytes.append(ZmodemHeaderEncoding.ZHEX.rawValue)
+
+    // Wire order: type, ZF0, ZF1, ZF2, ZF3 — which is p0, p1, p2, p3
+    let payload: [UInt8] = [header.type.rawValue, header.flags.3, header.flags.2, header.flags.1, header.flags.0]
+    let crc = zmodemCRC16(payload)
+
+    for b in payload {
+        bytes.append(contentsOf: hexEncode(b))
+    }
+    bytes.append(contentsOf: hexEncode(UInt8((crc >> 8) & 0xFF)))
+    bytes.append(contentsOf: hexEncode(UInt8(crc & 0xFF)))
+    bytes.append(ZmodemByte.CR)
+    bytes.append(ZmodemByte.LF)
+
+    // Append XON unless it's ZFIN or ZACK
+    if header.type != .ZFIN && header.type != .ZACK {
+        bytes.append(ZmodemByte.XON)
+    }
+
+    return Data(bytes)
+}
+
+/// Build a ZMODEM binary header with CRC-32
+public func zmodemEncodeBin32Header(_ header: ZmodemHeader) -> Data {
+    var bytes: [UInt8] = []
+    bytes.append(ZmodemByte.ZPAD)
+    bytes.append(ZmodemByte.ZDLE)
+    bytes.append(ZmodemHeaderEncoding.ZBIN32.rawValue)
+
+    // Wire order: type, ZF0, ZF1, ZF2, ZF3 — which is p0, p1, p2, p3
+    let payload: [UInt8] = [header.type.rawValue, header.flags.3, header.flags.2, header.flags.1, header.flags.0]
+    let crc = zmodemCRC32(payload)
+
+    for b in payload {
+        zmodemAppendEscaped(b, to: &bytes)
+    }
+    let crcBytes: [UInt8] = [
+        UInt8(crc & 0xFF),
+        UInt8((crc >> 8) & 0xFF),
+        UInt8((crc >> 16) & 0xFF),
+        UInt8((crc >> 24) & 0xFF),
+    ]
+    for b in crcBytes {
+        zmodemAppendEscaped(b, to: &bytes)
+    }
+
+    return Data(bytes)
+}
+
+// MARK: - Hex Header Parsing
+
+/// Attempt to parse a hex header from a buffer starting after "ZPAD ZPAD ZDLE ZHEX".
+/// Returns the parsed header and the number of bytes consumed (including trailing CR LF [XON]),
+/// or nil if the buffer is incomplete / invalid.
+public func zmodemParseHexHeader(_ buffer: ArraySlice<UInt8>) -> (header: ZmodemHeader, consumed: Int)? {
+    // Need at least 14 hex chars (type[2] + 4*flags[8] + crc[4]) = 14 hex chars
+    guard buffer.count >= 14 else { return nil }
+    let startIndex = buffer.startIndex
+
+    guard let typeByte = hexDecode(buffer[startIndex], buffer[startIndex + 1]),
+          let f0 = hexDecode(buffer[startIndex + 2], buffer[startIndex + 3]),
+          let f1 = hexDecode(buffer[startIndex + 4], buffer[startIndex + 5]),
+          let f2 = hexDecode(buffer[startIndex + 6], buffer[startIndex + 7]),
+          let f3 = hexDecode(buffer[startIndex + 8], buffer[startIndex + 9]),
+          let crcHi = hexDecode(buffer[startIndex + 10], buffer[startIndex + 11]),
+          let crcLo = hexDecode(buffer[startIndex + 12], buffer[startIndex + 13])
+    else { return nil }
+
+    guard let frameType = ZmodemFrameType(rawValue: typeByte) else { return nil }
+
+    let payload: [UInt8] = [typeByte, f0, f1, f2, f3]
+    let expectedCRC = zmodemCRC16(payload)
+    let actualCRC = (UInt16(crcHi) << 8) | UInt16(crcLo)
+    guard expectedCRC == actualCRC else { return nil }
+
+    // Skip trailing CR LF [XON]
+    var consumed = 14
+    let remaining = buffer.dropFirst(14)
+    var skip = remaining.startIndex
+    if skip < remaining.endIndex, remaining[skip] == ZmodemByte.CR { skip += 1; consumed += 1 }
+    if skip < remaining.endIndex, remaining[skip] == ZmodemByte.LF { skip += 1; consumed += 1 }
+    if skip < remaining.endIndex, remaining[skip] == ZmodemByte.XON { skip += 1; consumed += 1 }
+
+    let header = ZmodemHeader(type: frameType, p0: f0, p1: f1, p2: f2, p3: f3)
+    return (header, consumed)
+}
+
+// MARK: - Binary Header Parsing (CRC-16)
+
+public func zmodemParseBinHeader(_ buffer: ArraySlice<UInt8>) -> (header: ZmodemHeader, consumed: Int)? {
+    var idx = buffer.startIndex
+    var decoded: [UInt8] = []
+    // Need 5 payload bytes + 2 CRC bytes = 7 decoded bytes
+    while decoded.count < 7, idx < buffer.endIndex {
+        let b = buffer[idx]
+        idx += 1
+        if b == ZmodemByte.ZDLE {
+            guard idx < buffer.endIndex else { return nil }
+            let next = buffer[idx]
+            idx += 1
+            decoded.append(next ^ 0x40)
+        } else {
+            decoded.append(b)
+        }
+    }
+    guard decoded.count >= 7 else { return nil }
+
+    guard let frameType = ZmodemFrameType(rawValue: decoded[0]) else { return nil }
+    let payload = Array(decoded[0..<5])
+    let expectedCRC = zmodemCRC16(payload)
+    let actualCRC = (UInt16(decoded[5]) << 8) | UInt16(decoded[6])
+    guard expectedCRC == actualCRC else { return nil }
+
+    let header = ZmodemHeader(type: frameType, p0: decoded[1], p1: decoded[2], p2: decoded[3], p3: decoded[4])
+    return (header, idx - buffer.startIndex)
+}
+
+// MARK: - Binary Header Parsing (CRC-32)
+
+public func zmodemParseBin32Header(_ buffer: ArraySlice<UInt8>) -> (header: ZmodemHeader, consumed: Int)? {
+    var idx = buffer.startIndex
+    var decoded: [UInt8] = []
+    // Need 5 payload bytes + 4 CRC bytes = 9 decoded bytes
+    while decoded.count < 9, idx < buffer.endIndex {
+        let b = buffer[idx]
+        idx += 1
+        if b == ZmodemByte.ZDLE {
+            guard idx < buffer.endIndex else { return nil }
+            let next = buffer[idx]
+            idx += 1
+            decoded.append(next ^ 0x40)
+        } else {
+            decoded.append(b)
+        }
+    }
+    guard decoded.count >= 9 else { return nil }
+
+    guard let frameType = ZmodemFrameType(rawValue: decoded[0]) else { return nil }
+    let payload = Array(decoded[0..<5])
+    let expectedCRC = zmodemCRC32(payload)
+    let actualCRC = UInt32(decoded[5])
+        | (UInt32(decoded[6]) << 8)
+        | (UInt32(decoded[7]) << 16)
+        | (UInt32(decoded[8]) << 24)
+    guard expectedCRC == actualCRC else { return nil }
+
+    let header = ZmodemHeader(type: frameType, p0: decoded[1], p1: decoded[2], p2: decoded[3], p3: decoded[4])
+    return (header, idx - buffer.startIndex)
+}
+
+// MARK: - Sub-packet Data Parsing (CRC-32)
+
+/// Parse a ZMODEM data sub-packet with CRC-32.
+/// Returns (payload, subPacketType, bytesConsumed) or nil if incomplete/invalid.
+public func zmodemParseSubPacket32(_ buffer: ArraySlice<UInt8>) -> (data: Data, end: ZmodemSubPacketType, consumed: Int)? {
+    var idx = buffer.startIndex
+    var payload: [UInt8] = []
+
+    // Scan for ZDLE + sub-packet-type
+    while idx < buffer.endIndex {
+        let b = buffer[idx]
+        idx += 1
+
+        if b == ZmodemByte.ZDLE {
+            guard idx < buffer.endIndex else { return nil }
+            let next = buffer[idx]
+            idx += 1
+
+            if let subType = ZmodemSubPacketType(rawValue: next) {
+                // Found end marker. Next 4 bytes (escaped) are CRC-32
+                var crcBytes: [UInt8] = []
+                while crcBytes.count < 4, idx < buffer.endIndex {
+                    let cb = buffer[idx]
+                    idx += 1
+                    if cb == ZmodemByte.ZDLE {
+                        guard idx < buffer.endIndex else { return nil }
+                        let cn = buffer[idx]
+                        idx += 1
+                        crcBytes.append(cn ^ 0x40)
+                    } else {
+                        crcBytes.append(cb)
+                    }
+                }
+                guard crcBytes.count == 4 else { return nil }
+
+                // CRC covers payload + sub-packet type byte
+                var crcInput = payload
+                crcInput.append(subType.rawValue)
+                let expectedCRC = zmodemCRC32(crcInput)
+                let actualCRC = UInt32(crcBytes[0])
+                    | (UInt32(crcBytes[1]) << 8)
+                    | (UInt32(crcBytes[2]) << 16)
+                    | (UInt32(crcBytes[3]) << 24)
+                guard expectedCRC == actualCRC else { return nil }
+
+                return (Data(payload), subType, idx - buffer.startIndex)
+            } else {
+                // Escaped data byte
+                payload.append(next ^ 0x40)
+            }
+        } else {
+            payload.append(b)
+        }
+    }
+
+    return nil // Incomplete
+}
+
+// MARK: - Sub-packet Data Parsing (CRC-16)
+
+public func zmodemParseSubPacket16(_ buffer: ArraySlice<UInt8>) -> (data: Data, end: ZmodemSubPacketType, consumed: Int)? {
+    var idx = buffer.startIndex
+    var payload: [UInt8] = []
+
+    while idx < buffer.endIndex {
+        let b = buffer[idx]
+        idx += 1
+
+        if b == ZmodemByte.ZDLE {
+            guard idx < buffer.endIndex else { return nil }
+            let next = buffer[idx]
+            idx += 1
+
+            if let subType = ZmodemSubPacketType(rawValue: next) {
+                var crcBytes: [UInt8] = []
+                while crcBytes.count < 2, idx < buffer.endIndex {
+                    let cb = buffer[idx]
+                    idx += 1
+                    if cb == ZmodemByte.ZDLE {
+                        guard idx < buffer.endIndex else { return nil }
+                        let cn = buffer[idx]
+                        idx += 1
+                        crcBytes.append(cn ^ 0x40)
+                    } else {
+                        crcBytes.append(cb)
+                    }
+                }
+                guard crcBytes.count == 2 else { return nil }
+
+                var crcInput = payload
+                crcInput.append(subType.rawValue)
+                let expectedCRC = zmodemCRC16(crcInput)
+                let actualCRC = (UInt16(crcBytes[0]) << 8) | UInt16(crcBytes[1])
+                guard expectedCRC == actualCRC else { return nil }
+
+                return (Data(payload), subType, idx - buffer.startIndex)
+            } else {
+                payload.append(next ^ 0x40)
+            }
+        } else {
+            payload.append(b)
+        }
+    }
+
+    return nil
+}
+
+// MARK: - Sub-packet Data Encoding (CRC-32)
+
+/// Encode a ZMODEM data sub-packet with CRC-32.
+public func zmodemEncodeSubPacket32(_ data: Data, type: ZmodemSubPacketType) -> Data {
+    var bytes: [UInt8] = []
+    let raw = Array(data)
+
+    for b in raw {
+        zmodemAppendEscaped(b, to: &bytes)
+    }
+
+    // ZDLE + sub-packet type
+    bytes.append(ZmodemByte.ZDLE)
+    bytes.append(type.rawValue)
+
+    // CRC-32 covers payload + sub-packet type byte
+    var crcInput = raw
+    crcInput.append(type.rawValue)
+    let crc = zmodemCRC32(crcInput)
+    let crcBytes: [UInt8] = [
+        UInt8(crc & 0xFF),
+        UInt8((crc >> 8) & 0xFF),
+        UInt8((crc >> 16) & 0xFF),
+        UInt8((crc >> 24) & 0xFF),
+    ]
+    for b in crcBytes {
+        zmodemAppendEscaped(b, to: &bytes)
+    }
+
+    return Data(bytes)
+}
+
+// MARK: - Helpers
+
+private func hexEncode(_ byte: UInt8) -> [UInt8] {
+    let hi = byte >> 4
+    let lo = byte & 0x0F
+    return [hexChar(hi), hexChar(lo)]
+}
+
+private func hexChar(_ nibble: UInt8) -> UInt8 {
+    nibble < 10 ? (0x30 + nibble) : (0x61 + nibble - 10)
+}
+
+private func hexDecode(_ hi: UInt8, _ lo: UInt8) -> UInt8? {
+    guard let h = hexVal(hi), let l = hexVal(lo) else { return nil }
+    return (h << 4) | l
+}
+
+private func hexVal(_ c: UInt8) -> UInt8? {
+    switch c {
+    case 0x30...0x39: return c - 0x30
+    case 0x41...0x46: return c - 0x41 + 10
+    case 0x61...0x66: return c - 0x61 + 10
+    default: return nil
+    }
+}
+
+/// Append a byte with ZDLE escaping if needed.
+/// Escapes all control characters (0x00-0x1F, 0x7F, 0x80-0x9F) for maximum
+/// compatibility with bastion hosts and multi-hop SSH connections.
+func zmodemAppendEscaped(_ byte: UInt8, to buffer: inout [UInt8]) {
+    switch byte {
+    case ZmodemByte.ZDLE:
+        buffer.append(ZmodemByte.ZDLE)
+        buffer.append(ZmodemByte.ZDLEE)
+    case 0x10, 0x11, 0x13, 0x0D:
+        // DLE, XON, XOFF, CR — always escape
+        buffer.append(ZmodemByte.ZDLE)
+        buffer.append(byte ^ 0x40)
+    case 0x00...0x1F, 0x7F, 0x80...0x9F:
+        // All control characters — escape for -e compatibility
+        buffer.append(ZmodemByte.ZDLE)
+        buffer.append(byte ^ 0x40)
+    default:
+        buffer.append(byte)
+    }
+}

--- a/Sources/RemoraCore/ZModem/ZmodemSendEngine.swift
+++ b/Sources/RemoraCore/ZModem/ZmodemSendEngine.swift
@@ -1,0 +1,388 @@
+import Foundation
+
+// MARK: - ZMODEM Send Engine
+
+/// ZMODEM send state machine for uploading files (rz on remote).
+///
+/// Protocol flow (sender perspective):
+/// 1. Remote rz sends ZRINIT → we detect it via ZmodemDetector
+/// 2. Host calls setFiles() after user picks files
+/// 3. We send ZFILE header + filename sub-packet
+/// 4. Remote responds with ZRPOS (offset to start from)
+/// 5. We send ZDATA header + data sub-packets
+/// 6. We send ZEOF header
+/// 7. Remote sends ZRINIT (ready for next file) or we send ZFIN
+/// 8. Remote responds with ZFIN, we send "OO" to finish
+public final class ZmodemSendEngine: @unchecked Sendable {
+    public typealias EventHandler = @Sendable (ZmodemEvent) -> Void
+
+    private enum State {
+        case waitingForFiles    // Buffering data until host calls setFiles
+        case waitingForZRINIT   // Files set, waiting for ZRINIT to start sending
+        case waitingForZRPOS
+        case sendingData
+        case waitingForZRINITAfterEOF
+        case waitingForFinalZFIN
+        case finished
+    }
+
+    private var state: State = .waitingForFiles
+    private var buffer = Data()
+    private let onEvent: EventHandler
+
+    // File queue
+    private var fileQueue: [(url: URL, name: String, size: Int64)] = []
+    private var currentFileData: Data?
+    private var currentFileName: String = ""
+    private var currentFileSize: Int64 = 0
+    private var bytesSent: Int64 = 0
+    private var znakRetryCount = 0
+    private let maxZnakRetries = 5
+
+    private let subPacketSize = 1024
+
+    // Debug logging
+    private static func log(_ message: String) {
+        #if DEBUG
+        NSLog("[ZmodemSend] %@", message)
+        #endif
+    }
+
+    public var isActive: Bool {
+        state != .finished
+    }
+
+    public init(onEvent: @escaping EventHandler) {
+        self.onEvent = onEvent
+    }
+
+    /// Set the files to upload. Transitions from waitingForFiles → waitingForZRINIT
+    /// and processes any buffered data.
+    public func setFiles(_ urls: [URL]) {
+        fileQueue = urls.compactMap { url in
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let size = attrs[.size] as? Int64 else { return nil }
+            return (url: url, name: url.lastPathComponent, size: size)
+        }
+        guard !fileQueue.isEmpty else {
+            cancel()
+            return
+        }
+        if state == .waitingForFiles {
+            state = .waitingForZRINIT
+            Self.log("setFiles: \(fileQueue.count) files, buffer has \(buffer.count) bytes")
+            processBuffer()
+        }
+    }
+
+    /// Feed raw PTY output data (remote responses) into the engine
+    public func feedOutput(_ data: Data) {
+        guard isActive else { return }
+        buffer.append(data)
+        Self.log("feedOutput: +\(data.count) bytes, total buffer=\(buffer.count), state=\(state)")
+
+        if buffer.count > 4 * 1024 * 1024 {
+            emit(.error("ZMODEM send buffer overflow"))
+            cancel()
+            return
+        }
+
+        // Don't process until files are set
+        guard state != .waitingForFiles else { return }
+        processBuffer()
+    }
+
+    /// Cancel the transfer
+    public func cancel() {
+        guard state != .finished else { return }
+        var abort: [UInt8] = []
+        for _ in 0..<8 { abort.append(ZmodemByte.ZDLE) }
+        for _ in 0..<8 { abort.append(0x08) }
+        emit(.sendToRemote(Data(abort)))
+        state = .finished
+        emit(.sessionFinished)
+    }
+
+    // MARK: - State Machine
+
+    private func processBuffer() {
+        var iterations = 0
+        let maxIterations = 200
+
+        while !buffer.isEmpty, isActive, state != .waitingForFiles, iterations < maxIterations {
+            iterations += 1
+            let consumed: Bool
+
+            switch state {
+            case .waitingForFiles:
+                consumed = false
+            case .waitingForZRINIT:
+                consumed = handleWaitingForZRINIT()
+            case .waitingForZRPOS:
+                consumed = handleWaitingForZRPOS()
+            case .sendingData:
+                consumed = false
+            case .waitingForZRINITAfterEOF:
+                consumed = handleWaitingForZRINITAfterEOF()
+            case .waitingForFinalZFIN:
+                consumed = handleWaitingForFinalZFIN()
+            case .finished:
+                consumed = false
+            }
+
+            if !consumed { break }
+        }
+    }
+
+    private func handleWaitingForZRINIT() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else {
+            Self.log("waitingForZRINIT: no header found in \(buffer.count) bytes")
+            if buffer.count > 0 {
+                let preview = Array(buffer.prefix(min(buffer.count, 64)))
+                Self.log("  buffer hex: \(preview.map { String(format: "%02X", $0) }.joined(separator: " "))")
+            }
+            return false
+        }
+        buffer.removeFirst(consumed)
+        Self.log("waitingForZRINIT: got header type=\(header.type) consumed=\(consumed)")
+
+        if header.type == .ZRINIT {
+            sendNextFile()
+            return true
+        }
+        return true
+    }
+
+    private func handleWaitingForZRPOS() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else {
+            Self.log("waitingForZRPOS: no header found in \(buffer.count) bytes")
+            return false
+        }
+        buffer.removeFirst(consumed)
+        Self.log("waitingForZRPOS: got header type=\(header.type)")
+
+        if header.type == .ZRPOS {
+            let offset = header.position
+            bytesSent = Int64(offset)
+            state = .sendingData
+            sendFileData(from: offset)
+            return true
+        }
+        if header.type == .ZSKIP {
+            sendNextFile()
+            return true
+        }
+        if header.type == .ZABORT {
+            state = .finished
+            emit(.sessionFinished)
+            return true
+        }
+        if header.type == .ZRINIT {
+            // rz resends ZRINIT before it processes our ZFILE — just ignore it
+            Self.log("waitingForZRPOS: ignoring stale ZRINIT")
+            return true
+        }
+        if header.type == .ZNAK {
+            // rz couldn't parse our last packet — resend ZFILE
+            znakRetryCount += 1
+            Self.log("waitingForZRPOS: got ZNAK #\(znakRetryCount), resending ZFILE")
+            if znakRetryCount > maxZnakRetries {
+                Self.log("waitingForZRPOS: too many ZNAKs, aborting")
+                emit(.error("Transfer failed: too many retries"))
+                cancel()
+                return true
+            }
+            resendCurrentZFILE()
+            return true
+        }
+        return true
+    }
+
+    private func handleWaitingForZRINITAfterEOF() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else { return false }
+        buffer.removeFirst(consumed)
+
+        if header.type == .ZRINIT {
+            sendNextFile()
+            return true
+        }
+        if header.type == .ZACK {
+            return true
+        }
+        return true
+    }
+
+    private func handleWaitingForFinalZFIN() -> Bool {
+        guard let (header, consumed) = parseNextHeader() else { return false }
+        buffer.removeFirst(consumed)
+
+        if header.type == .ZFIN {
+            emit(.sendToRemote(Data([0x4F, 0x4F]))) // "OO"
+            state = .finished
+            emit(.sessionFinished)
+            return true
+        }
+        return true
+    }
+
+    // MARK: - File Sending
+
+    private func sendNextFile() {
+        guard !fileQueue.isEmpty else {
+            let fin = ZmodemHeader(type: .ZFIN)
+            emit(.sendToRemote(zmodemEncodeHexHeader(fin)))
+            state = .waitingForFinalZFIN
+            return
+        }
+
+        let file = fileQueue.removeFirst()
+        currentFileName = file.name
+        currentFileSize = file.size
+        bytesSent = 0
+        znakRetryCount = 0
+
+        guard let data = try? Data(contentsOf: file.url) else {
+            emit(.error("Failed to read file: \(file.name)"))
+            sendNextFile()
+            return
+        }
+        currentFileData = data
+        sendZFILE()
+    }
+
+    private func sendZFILE() {
+        Self.log("sendZFILE: sending ZFILE for '\(currentFileName)' size=\(currentFileSize)")
+
+        // Use ZBIN32 header + CRC-32 sub-packet (must be consistent)
+        let zfile = ZmodemHeader(type: .ZFILE)
+        let headerData = zmodemEncodeBin32Header(zfile)
+
+        // Sub-packet: "name\0size modtime filemode serialnumber filesremaining bytesremaining\0"
+        var info: [UInt8] = Array(currentFileName.utf8)
+        info.append(0)
+        let meta = "\(currentFileSize) 0 0 0 1 \(currentFileSize)"
+        info.append(contentsOf: Array(meta.utf8))
+        info.append(0)
+        let subPacketData = zmodemEncodeSubPacket32(Data(info), type: .ZCRCW)
+
+        // Send header + sub-packet as a single write to avoid fragmentation
+        var combined = headerData
+        combined.append(subPacketData)
+        Self.log("sendZFILE: total \(combined.count) bytes, header=\(headerData.count) sub=\(subPacketData.count)")
+        let preview = Array(combined.prefix(min(combined.count, 80)))
+        Self.log("sendZFILE hex: \(preview.map { String(format: "%02X", $0) }.joined(separator: " "))")
+        emit(.sendToRemote(combined))
+
+        state = .waitingForZRPOS
+        emit(.progress(ZmodemProgress(fileName: currentFileName, fileSize: currentFileSize, bytesTransferred: 0)))
+    }
+
+    private func resendCurrentZFILE() {
+        guard currentFileData != nil else { return }
+        sendZFILE()
+    }
+
+    private func sendFileData(from offset: UInt32) {
+        guard let fileData = currentFileData else { return }
+        Self.log("sendFileData: from offset=\(offset), total=\(fileData.count)")
+
+        // Build entire ZDATA frame as one contiguous buffer to avoid fragmentation
+        var frame = Data()
+
+        // ZDATA header — use ZBIN32 to match CRC-32 sub-packets
+        let zdata = ZmodemHeader.withPosition(type: .ZDATA, offset)
+        frame.append(zmodemEncodeBin32Header(zdata))
+
+        var pos = Int(offset)
+        let total = fileData.count
+
+        while pos < total {
+            let end = min(pos + subPacketSize, total)
+            let chunk = fileData[pos..<end]
+            let isLast = end >= total
+
+            let subType: ZmodemSubPacketType = isLast ? .ZCRCE : .ZCRCG
+            frame.append(zmodemEncodeSubPacket32(Data(chunk), type: subType))
+
+            pos = end
+            bytesSent = Int64(pos)
+        }
+
+        // Send entire frame as one write
+        emit(.sendToRemote(frame))
+
+        emit(.progress(ZmodemProgress(
+            fileName: currentFileName,
+            fileSize: currentFileSize,
+            bytesTransferred: bytesSent
+        )))
+
+        // Send ZEOF
+        let zeof = ZmodemHeader.withPosition(type: .ZEOF, UInt32(total))
+        emit(.sendToRemote(zmodemEncodeHexHeader(zeof)))
+
+        state = .waitingForZRINITAfterEOF
+        emit(.progress(ZmodemProgress(
+            fileName: currentFileName,
+            fileSize: currentFileSize,
+            bytesTransferred: bytesSent,
+            finished: true
+        )))
+        currentFileData = nil
+    }
+
+    // MARK: - Header Parsing
+
+    private func parseNextHeader() -> (ZmodemHeader, Int)? {
+        let bytes = Array(buffer)
+        let slice = bytes[...]
+
+        for i in slice.indices {
+            if i + 3 < slice.endIndex,
+               slice[i] == ZmodemByte.ZPAD,
+               slice[i + 1] == ZmodemByte.ZPAD,
+               slice[i + 2] == ZmodemByte.ZDLE,
+               slice[i + 3] == ZmodemHeaderEncoding.ZHEX.rawValue
+            {
+                let headerStart = i + 4
+                guard headerStart < slice.endIndex else { return nil }
+                if let (header, hConsumed) = zmodemParseHexHeader(slice[headerStart...]) {
+                    return (header, headerStart + hConsumed - slice.startIndex)
+                }
+                return nil
+            }
+
+            if i + 2 < slice.endIndex,
+               slice[i] == ZmodemByte.ZPAD,
+               slice[i + 1] == ZmodemByte.ZDLE,
+               slice[i + 2] == ZmodemHeaderEncoding.ZBIN32.rawValue
+            {
+                let headerStart = i + 3
+                guard headerStart < slice.endIndex else { return nil }
+                if let (header, hConsumed) = zmodemParseBin32Header(slice[headerStart...]) {
+                    return (header, headerStart + hConsumed - slice.startIndex)
+                }
+                return nil
+            }
+
+            if i + 2 < slice.endIndex,
+               slice[i] == ZmodemByte.ZPAD,
+               slice[i + 1] == ZmodemByte.ZDLE,
+               slice[i + 2] == ZmodemHeaderEncoding.ZBIN.rawValue
+            {
+                let headerStart = i + 3
+                guard headerStart < slice.endIndex else { return nil }
+                if let (header, hConsumed) = zmodemParseBinHeader(slice[headerStart...]) {
+                    return (header, headerStart + hConsumed - slice.startIndex)
+                }
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    private func emit(_ event: ZmodemEvent) {
+        onEvent(event)
+    }
+}

--- a/Sources/RemoraCore/ZModem/ZmodemSendEngine.swift
+++ b/Sources/RemoraCore/ZModem/ZmodemSendEngine.swift
@@ -70,7 +70,6 @@ public final class ZmodemSendEngine: @unchecked Sendable {
         }
         if state == .waitingForFiles {
             state = .waitingForZRINIT
-            Self.log("setFiles: \(fileQueue.count) files, buffer has \(buffer.count) bytes")
             processBuffer()
         }
     }
@@ -79,7 +78,6 @@ public final class ZmodemSendEngine: @unchecked Sendable {
     public func feedOutput(_ data: Data) {
         guard isActive else { return }
         buffer.append(data)
-        Self.log("feedOutput: +\(data.count) bytes, total buffer=\(buffer.count), state=\(state)")
 
         if buffer.count > 4 * 1024 * 1024 {
             emit(.error("ZMODEM send buffer overflow"))
@@ -135,16 +133,8 @@ public final class ZmodemSendEngine: @unchecked Sendable {
     }
 
     private func handleWaitingForZRINIT() -> Bool {
-        guard let (header, consumed) = parseNextHeader() else {
-            Self.log("waitingForZRINIT: no header found in \(buffer.count) bytes")
-            if buffer.count > 0 {
-                let preview = Array(buffer.prefix(min(buffer.count, 64)))
-                Self.log("  buffer hex: \(preview.map { String(format: "%02X", $0) }.joined(separator: " "))")
-            }
-            return false
-        }
+        guard let (header, consumed) = parseNextHeader() else { return false }
         buffer.removeFirst(consumed)
-        Self.log("waitingForZRINIT: got header type=\(header.type) consumed=\(consumed)")
 
         if header.type == .ZRINIT {
             sendNextFile()
@@ -154,12 +144,8 @@ public final class ZmodemSendEngine: @unchecked Sendable {
     }
 
     private func handleWaitingForZRPOS() -> Bool {
-        guard let (header, consumed) = parseNextHeader() else {
-            Self.log("waitingForZRPOS: no header found in \(buffer.count) bytes")
-            return false
-        }
+        guard let (header, consumed) = parseNextHeader() else { return false }
         buffer.removeFirst(consumed)
-        Self.log("waitingForZRPOS: got header type=\(header.type)")
 
         if header.type == .ZRPOS {
             let offset = header.position
@@ -179,15 +165,11 @@ public final class ZmodemSendEngine: @unchecked Sendable {
         }
         if header.type == .ZRINIT {
             // rz resends ZRINIT before it processes our ZFILE — just ignore it
-            Self.log("waitingForZRPOS: ignoring stale ZRINIT")
             return true
         }
         if header.type == .ZNAK {
-            // rz couldn't parse our last packet — resend ZFILE
             znakRetryCount += 1
-            Self.log("waitingForZRPOS: got ZNAK #\(znakRetryCount), resending ZFILE")
             if znakRetryCount > maxZnakRetries {
-                Self.log("waitingForZRPOS: too many ZNAKs, aborting")
                 emit(.error("Transfer failed: too many retries"))
                 cancel()
                 return true
@@ -251,9 +233,6 @@ public final class ZmodemSendEngine: @unchecked Sendable {
     }
 
     private func sendZFILE() {
-        Self.log("sendZFILE: sending ZFILE for '\(currentFileName)' size=\(currentFileSize)")
-
-        // Use ZBIN32 header + CRC-32 sub-packet (must be consistent)
         let zfile = ZmodemHeader(type: .ZFILE)
         let headerData = zmodemEncodeBin32Header(zfile)
 
@@ -268,9 +247,6 @@ public final class ZmodemSendEngine: @unchecked Sendable {
         // Send header + sub-packet as a single write to avoid fragmentation
         var combined = headerData
         combined.append(subPacketData)
-        Self.log("sendZFILE: total \(combined.count) bytes, header=\(headerData.count) sub=\(subPacketData.count)")
-        let preview = Array(combined.prefix(min(combined.count, 80)))
-        Self.log("sendZFILE hex: \(preview.map { String(format: "%02X", $0) }.joined(separator: " "))")
         emit(.sendToRemote(combined))
 
         state = .waitingForZRPOS
@@ -284,7 +260,6 @@ public final class ZmodemSendEngine: @unchecked Sendable {
 
     private func sendFileData(from offset: UInt32) {
         guard let fileData = currentFileData else { return }
-        Self.log("sendFileData: from offset=\(offset), total=\(fileData.count)")
 
         // Build entire ZDATA frame as one contiguous buffer to avoid fragmentation
         var frame = Data()

--- a/Tests/RemoraCoreTests/SSHConnectionReusePolicyTests.swift
+++ b/Tests/RemoraCoreTests/SSHConnectionReusePolicyTests.swift
@@ -13,9 +13,9 @@ struct SSHConnectionReusePolicyTests {
     }
 
     @Test
-    func passwordAuthWithStoredPasswordAlsoUsesConnectionReuse() {
+    func passwordAuthWithStoredPasswordDoesNotRequireConnectionReuse() {
         #expect(
-            SSHConnectionReusePolicy.shouldUseConnectionReuse(
+            !SSHConnectionReusePolicy.shouldUseConnectionReuse(
                 authMethod: .password,
                 hasStoredPassword: true
             )

--- a/Tests/RemoraCoreTests/SSHConnectionReusePolicyTests.swift
+++ b/Tests/RemoraCoreTests/SSHConnectionReusePolicyTests.swift
@@ -13,9 +13,9 @@ struct SSHConnectionReusePolicyTests {
     }
 
     @Test
-    func passwordAuthWithStoredPasswordDoesNotRequireConnectionReuse() {
+    func passwordAuthWithStoredPasswordAlsoUsesConnectionReuse() {
         #expect(
-            !SSHConnectionReusePolicy.shouldUseConnectionReuse(
+            SSHConnectionReusePolicy.shouldUseConnectionReuse(
                 authMethod: .password,
                 hasStoredPassword: true
             )


### PR DESCRIPTION
#MODEM (rz/sz)：在 RemoraCore/ZModem/ 新增了 5 个文件实现 ZMODEM 协议——检测器、帧编解码、CRC 校验、接收引擎（sz 下载）和发送引擎（rz 上传）。在 TerminalRuntime.flushOutputBatch 做拦截，ZmodemTransferCoordinator 负责文件对话框和 PTY I/O 编排。全控制字符转义以兼容堡垒机多层跳转。

克隆会话：在右键菜单加了"克隆会话"，利用 SSH ControlMaster 复用已有连接。同时把密码认证也启用了 ControlMaster，这样克隆时不需要重新输入密码/2FA。