### PR TITLE
Use forked SwiftTerm and tune terminal rendering

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .executable(name: "terminal-stress", targets: ["TerminalStressTool"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.13.0"),
+        .package(url: "https://github.com/wuuJiawei/SwiftTerm", branch: "main"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .executable(name: "terminal-stress", targets: ["TerminalStressTool"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/wuuJiawei/SwiftTerm", branch: "main"),
+        .package(url: "https://github.com/wuuJiawei/SwiftTerm", revision: "4f632d1c60be15ad70152b006cb8679fc81c764f"),
     ],
     targets: [
         .target(

--- a/Sources/RemoraTerminal/TerminalView.swift
+++ b/Sources/RemoraTerminal/TerminalView.swift
@@ -89,6 +89,30 @@ public struct TerminalActionShortcut: Equatable {
     }
 }
 
+public struct TerminalRenderingConfiguration: Equatable {
+    public var coalescesOutput: Bool
+    public var outputFlushInterval: TimeInterval
+    public var maxPendingOutputBytes: Int
+    public var maxOutputBytesPerFlush: Int
+    public var automaticallyEnableMetal: Bool
+
+    public init(
+        coalescesOutput: Bool = true,
+        outputFlushInterval: TimeInterval = 1.0 / 120.0,
+        maxPendingOutputBytes: Int = 512 * 1024,
+        maxOutputBytesPerFlush: Int = 32 * 1024,
+        automaticallyEnableMetal: Bool = true
+    ) {
+        self.coalescesOutput = coalescesOutput
+        self.outputFlushInterval = outputFlushInterval
+        self.maxPendingOutputBytes = maxPendingOutputBytes
+        self.maxOutputBytesPerFlush = maxOutputBytesPerFlush
+        self.automaticallyEnableMetal = automaticallyEnableMetal
+    }
+
+    public static let interactiveSSH = TerminalRenderingConfiguration()
+}
+
 public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTerm.TerminalViewDelegate {
     private static let selectionAutoscrollInterval: TimeInterval = 1.0 / 30.0
 
@@ -98,6 +122,16 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
     public var onClearScreen: (() -> Void)?
     public var actionLabels = TerminalActionLabels()
 
+    public var renderingConfiguration: TerminalRenderingConfiguration = .interactiveSSH {
+        didSet {
+            rebuildOutputCoalescerIfNeeded()
+            configureMetalIfNeeded()
+        }
+    }
+
+    public private(set) var isMetalRenderingEnabledByRemora = false
+
+    private var outputCoalescer: TerminalFeedCoalescer?
     private var selectionAutoscrollTimer: Timer?
     private var selectionEventMonitor: Any?
 
@@ -119,6 +153,7 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
     public override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         installSelectionEventMonitorIfNeeded()
+        configureMetalIfNeeded()
         DispatchQueue.main.async { [weak self] in
             self?.focusTerminal()
         }
@@ -138,7 +173,23 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
     }
 
     public func feed(data: Data) {
-        feed(byteArray: ArraySlice(data))
+        if renderingConfiguration.coalescesOutput {
+            outputCoalescer?.append(data: data)
+        } else {
+            feed(byteArray: ArraySlice(data))
+        }
+    }
+
+    public func flushPendingOutput() {
+        outputCoalescer?.flushAll()
+    }
+
+    public var pendingOutputByteCount: Int {
+        outputCoalescer?.pendingByteCount ?? 0
+    }
+
+    public var droppedOutputByteCount: UInt64 {
+        outputCoalescer?.droppedByteCount ?? 0
     }
 
     public var hasSelection: Bool {
@@ -227,7 +278,41 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
         resize(cols: columns, rows: rows)
         frame = getOptimalFrameSize()
         setAccessibilityIdentifier("terminal-view")
+        rebuildOutputCoalescerIfNeeded()
         installSelectionEventMonitorIfNeeded()
+    }
+
+    private func rebuildOutputCoalescerIfNeeded() {
+        outputCoalescer?.flushAll()
+        outputCoalescer?.invalidate()
+        outputCoalescer = nil
+
+        guard renderingConfiguration.coalescesOutput else {
+            return
+        }
+
+        outputCoalescer = makeFeedCoalescer(
+            flushInterval: renderingConfiguration.outputFlushInterval,
+            maxPendingBytes: renderingConfiguration.maxPendingOutputBytes,
+            maxBytesPerFlush: renderingConfiguration.maxOutputBytesPerFlush,
+            backpressurePolicy: .keepOldest
+        )
+    }
+
+    private func configureMetalIfNeeded() {
+        guard renderingConfiguration.automaticallyEnableMetal,
+              window != nil,
+              !isMetalRenderingEnabledByRemora
+        else {
+            return
+        }
+
+        do {
+            try setUseMetal(true)
+            isMetalRenderingEnabledByRemora = true
+        } catch {
+            isMetalRenderingEnabledByRemora = false
+        }
     }
 
     public func sizeChanged(source: SwiftTerm.TerminalView, newCols: Int, newRows: Int) {
@@ -443,5 +528,9 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
         }
 
         mouseDragged(with: dragEvent)
+    }
+
+    deinit {
+        outputCoalescer?.invalidate()
     }
 }


### PR DESCRIPTION
## Summary

- Switch SwiftTerm dependency from upstream `migueldeicaza/SwiftTerm` to `wuuJiawei/SwiftTerm`.
- Pin the SwiftTerm fork by commit revision instead of a branch requirement, so Remora remains usable as a versioned SwiftPM dependency.
- Add `TerminalRenderingConfiguration` for Remora's terminal view.
- Route incoming SSH/terminal output through SwiftTerm's coalesced feed path by default.
- Attempt to enable SwiftTerm's Metal renderer automatically after the terminal view enters a window, with silent fallback if unavailable.
- Expose pending/dropped output counters and `flushPendingOutput()` for diagnostics and lifecycle handling.

## Conflict resolution

The previous PR was based on an older `TerminalView.swift` and conflicted with current `main` selection/context-menu/clear-screen code. This branch has been rebuilt on top of current `main`, preserving those existing features and applying only the SwiftTerm dependency/rendering changes.

## SwiftPM dependency note

This PR now uses:

```swift
.package(url: "https://github.com/wuuJiawei/SwiftTerm", revision: "4f632d1c60be15ad70152b006cb8679fc81c764f")
```

instead of `branch: "main"`. That avoids the SwiftPM issue where a versioned package cannot depend on branch-based requirements.

Longer term, the cleanest option is to tag the forked SwiftTerm with a semantic version and switch Remora to a version requirement.

## Default terminal output tuning

The default profile is for general interactive SSH/TUI usage, not log-only viewing:

```swift
TerminalRenderingConfiguration.interactiveSSH
```

Defaults:

- `coalescesOutput: true`
- `outputFlushInterval: 1.0 / 120.0`
- `maxPendingOutputBytes: 512 * 1024`
- `maxOutputBytesPerFlush: 32 * 1024`
- `automaticallyEnableMetal: true`
- backpressure uses `.keepOldest` internally to preserve terminal stream ordering.

## TERM / xterm-256color

`Sources/RemoraCore/SSH/SystemSSHClient.swift` already routes SSH through `mergedTerminalEnvironment(_:)` and falls back to `xterm-256color` when no explicit TERM is present.

TERM policy hardening is intentionally handled separately in a small focused PR.