### PR TITLE
Default SSH TERM to xterm-256color

### DIFF
--- a/Sources/RemoraCore/SSH/SystemSSHClient.swift
+++ b/Sources/RemoraCore/SSH/SystemSSHClient.swift
@@ -728,12 +728,9 @@ public final class ProcessSSHShellSession: SSHTransportSessionProtocol, @uncheck
 
     private static func mergedTerminalEnvironment(_ base: [String: String]) -> [String: String] {
         var environment = base
-        let inheritedTerm = ProcessInfo.processInfo.environment["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-
         if environment["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
-            environment["TERM"] = (inheritedTerm?.isEmpty == false ? inheritedTerm : nil) ?? "xterm-256color"
+            environment["TERM"] = "xterm-256color"
         }
-
         return environment
     }
 


### PR DESCRIPTION
## Summary

- Change `mergedTerminalEnvironment(_:)` so Remora defaults SSH sessions to `xterm-256color` instead of inheriting the launching process' ambient `TERM`.
- Preserve explicit `TERM` values passed by callers through the launch environment.

## Why

Remora is a GUI SSH client, and the app process may inherit different `TERM` values depending on how it was launched. Defaulting to `xterm-256color` gives interactive shells and TUI apps a stable terminal type by default.

This intentionally keeps the existing SSH launch structure unchanged and only changes the TERM fallback policy.