### PR TITLE
新增可配置的选中即复制与右键粘贴终端模式

### DIFF
--- a/Sources/RemoraApp/AppPreferences.swift
+++ b/Sources/RemoraApp/AppPreferences.swift
@@ -24,6 +24,7 @@ struct AppPreferencesSnapshot: Codable, Equatable {
     var serverMetricsInactiveRefreshSeconds: Int
     var serverMetricsMaxConcurrentFetches: Int
     var automaticallyCheckForUpdates: Bool
+    var terminalCopyOnSelect: Bool
 
     static func defaultValue(fileManager: FileManager = .default) -> AppPreferencesSnapshot {
         AppPreferencesSnapshot(
@@ -47,7 +48,8 @@ struct AppPreferencesSnapshot: Codable, Equatable {
             serverMetricsActiveRefreshSeconds: AppSettings.defaultServerMetricsActiveRefreshSeconds,
             serverMetricsInactiveRefreshSeconds: AppSettings.defaultServerMetricsInactiveRefreshSeconds,
             serverMetricsMaxConcurrentFetches: AppSettings.defaultServerMetricsMaxConcurrentFetches,
-            automaticallyCheckForUpdates: AppSettings.defaultAutomaticallyCheckForUpdates
+            automaticallyCheckForUpdates: AppSettings.defaultAutomaticallyCheckForUpdates,
+            terminalCopyOnSelect: false
         )
     }
 
@@ -89,6 +91,7 @@ extension AppPreferencesSnapshot {
         case serverMetricsInactiveRefreshSeconds
         case serverMetricsMaxConcurrentFetches
         case automaticallyCheckForUpdates
+        case terminalCopyOnSelect
     }
 
     init(from decoder: Decoder) throws {
@@ -115,6 +118,8 @@ extension AppPreferencesSnapshot {
         serverMetricsMaxConcurrentFetches = try container.decode(Int.self, forKey: .serverMetricsMaxConcurrentFetches)
         automaticallyCheckForUpdates = try container.decodeIfPresent(Bool.self, forKey: .automaticallyCheckForUpdates)
             ?? AppSettings.defaultAutomaticallyCheckForUpdates
+        terminalCopyOnSelect = try container.decodeIfPresent(Bool.self, forKey: .terminalCopyOnSelect)
+            ?? false
     }
 }
 

--- a/Sources/RemoraApp/RemoraSettingsSheet.swift
+++ b/Sources/RemoraApp/RemoraSettingsSheet.swift
@@ -65,6 +65,7 @@ struct RemoraSettingsSheet: View {
     @RemoraStored(\.appearanceModeRawValue) private var appearanceModeRawValue: String
     @RemoraStored(\.downloadDirectoryPath) private var downloadDirectoryPath: String
     @RemoraStored(\.automaticallyCheckForUpdates) private var automaticallyCheckForUpdates: Bool
+    @RemoraStored(\.terminalCopyOnSelect) private var terminalCopyOnSelect: Bool
     @RemoraStored(\.aiEnabled) private var aiEnabled: Bool
     @RemoraStored(\.aiProviderRawValue) private var aiProviderRawValue: String
     @RemoraStored(\.aiAPIFormatRawValue) private var aiAPIFormatRawValue: String
@@ -251,6 +252,17 @@ struct RemoraSettingsSheet: View {
                         }
                     }
                     .accessibilityIdentifier("settings-download-path-row")
+                }
+
+                settingsSectionCard(
+                    title: tr("Terminal"),
+                    message: tr("Select to copy, right-click to paste. Like a classic Linux terminal.")
+                ) {
+                    compactSettingRow(title: tr("Copy on select & right-click paste")) {
+                        Toggle("", isOn: $terminalCopyOnSelect)
+                            .labelsHidden()
+                            .accessibilityIdentifier("settings-terminal-copy-on-select")
+                    }
                 }
 
                 settingsSectionCard(

--- a/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
@@ -584,3 +584,8 @@
 "Receiving file…" = "Receiving file…";
 "Transfer complete" = "Transfer complete";
 "Cancel Transfer" = "Cancel Transfer";
+
+/* Terminal Behavior */
+"Terminal" = "Terminal";
+"Copy on select & right-click paste" = "Copy on select & right-click paste";
+"Select to copy, right-click to paste. Like a classic Linux terminal." = "Select to copy, right-click to paste. Like a classic Linux terminal.";

--- a/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -581,3 +581,8 @@
 "Receiving file…" = "正在接收文件…";
 "Transfer complete" = "传输完成";
 "Cancel Transfer" = "取消传输";
+
+/* Terminal Behavior */
+"Terminal" = "终端";
+"Copy on select & right-click paste" = "选中即复制，右键粘贴";
+"Select to copy, right-click to paste. Like a classic Linux terminal." = "选中文本自动复制，右键直接粘贴，类似经典 Linux 终端操作习惯。";

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -917,7 +917,8 @@ final class TerminalRuntime: ObservableObject {
     }
 
     private func updateDisplayLineState(with data: Data) {
-        for byte in data {
+        let sanitized = stripANSISequences(from: String(decoding: data, as: UTF8.self))
+        for byte in sanitized.utf8 {
             switch byte {
             case 0x0A, 0x0D:
                 displayEndsAtLineStart = true

--- a/Sources/RemoraApp/TerminalViewRepresentable.swift
+++ b/Sources/RemoraApp/TerminalViewRepresentable.swift
@@ -5,6 +5,7 @@ import RemoraTerminal
 struct TerminalViewRepresentable: NSViewRepresentable {
     let pane: TerminalPaneModel
     @ObservedObject var runtime: TerminalRuntime
+    @RemoraStored(\.terminalCopyOnSelect) private var terminalCopyOnSelect: Bool
     var onFocus: () -> Void = {}
     private var actionLabels: TerminalActionLabels {
         TerminalActionLabels(
@@ -34,6 +35,7 @@ struct TerminalViewRepresentable: NSViewRepresentable {
             runtime.resize(columns: columns, rows: rows)
         }
         view.actionLabels = actionLabels
+        view.copyOnSelect = terminalCopyOnSelect
         runtime.attach(view: view)
     }
 }

--- a/Sources/RemoraTerminal/TerminalView.swift
+++ b/Sources/RemoraTerminal/TerminalView.swift
@@ -121,6 +121,8 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
     public var onResize: ((Int, Int) -> Void)?
     public var onClearScreen: (() -> Void)?
     public var actionLabels = TerminalActionLabels()
+    public var copyOnSelect = false
+    private var mouseUpMonitor: Any?
 
     public var renderingConfiguration: TerminalRenderingConfiguration = .interactiveSSH {
         didSet {
@@ -157,6 +159,16 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
         DispatchQueue.main.async { [weak self] in
             self?.focusTerminal()
         }
+        if window != nil {
+            installMouseUpMonitorIfNeeded()
+        } else {
+            removeMouseUpMonitor()
+        }
+    }
+
+    public override func removeFromSuperview() {
+        removeMouseUpMonitor()
+        super.removeFromSuperview()
     }
 
     public override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -169,6 +181,10 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
 
     public override func menu(for event: NSEvent) -> NSMenu? {
         focusTerminal()
+        if copyOnSelect {
+            paste(self)
+            return nil
+        }
         return contextMenu()
     }
 
@@ -358,6 +374,28 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
     private func focusTerminal() {
         window?.makeFirstResponder(self)
         onFocus?()
+    }
+
+    private func installMouseUpMonitorIfNeeded() {
+        guard mouseUpMonitor == nil else { return }
+        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            guard let self, self.copyOnSelect, self.hasSelection else { return event }
+            let locationInView = self.convert(event.locationInWindow, from: nil)
+            if self.bounds.contains(locationInView) {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, self.copyOnSelect, self.hasSelection else { return }
+                    self.copy(self)
+                }
+            }
+            return event
+        }
+    }
+
+    private func removeMouseUpMonitor() {
+        if let monitor = mouseUpMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseUpMonitor = nil
+        }
     }
 
     private func contextMenu() -> NSMenu {

--- a/Tests/RemoraAppTests/AppSettingsTests.swift
+++ b/Tests/RemoraAppTests/AppSettingsTests.swift
@@ -137,6 +137,25 @@ struct AppSettingsTests {
         #expect(decoded.automaticallyCheckForUpdates == true)
     }
 
+    @MainActor
+    @Test
+    func terminalCopyOnSelectPersistsToPreferencesFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("remora-terminal-copy-on-select-\(UUID().uuidString)", isDirectory: true)
+        let fileURL = root.appendingPathComponent("settings.json", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let preferences = AppPreferences(fileURL: fileURL)
+        preferences.set(true, for: \.terminalCopyOnSelect)
+
+        let rawData = try Data(contentsOf: fileURL)
+        let rawObject = try #require(JSONSerialization.jsonObject(with: rawData) as? [String: Any])
+        #expect(rawObject["terminalCopyOnSelect"] as? Bool == true)
+
+        let reloaded = AppPreferences(fileURL: fileURL)
+        #expect(reloaded.value(for: \.terminalCopyOnSelect) == true)
+    }
+
     @Test
     func versionComparisonUsesNumericOrderingAndStripsTagPrefix() {
         #expect(UpdateChecker.normalizedVersion(" v0.14.3 ") == "0.14.3")

--- a/Tests/RemoraAppTests/TerminalViewTests.swift
+++ b/Tests/RemoraAppTests/TerminalViewTests.swift
@@ -88,6 +88,56 @@ struct TerminalViewTests {
     }
 
     @Test
+    func rightClickKeepsContextMenuWhenCopyOnSelectIsDisabled() throws {
+        let view = TerminalView(rows: 6, columns: 40)
+        view.copyOnSelect = false
+
+        let event = try #require(
+            NSEvent.mouseEvent(
+                with: .rightMouseUp,
+                location: .init(x: 10, y: 10),
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                eventNumber: 1,
+                clickCount: 1,
+                pressure: 1
+            )
+        )
+
+        let menu = view.menu(for: event)
+        #expect(menu != nil)
+        #expect(menu?.items.contains(where: { $0.action == #selector(TerminalView.paste(_:)) }) == true)
+    }
+
+    @Test
+    func rightClickTriggersPasteWhenCopyOnSelectIsEnabled() throws {
+        let view = TerminalView(rows: 6, columns: 40)
+        view.copyOnSelect = true
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("copied text", forType: .string)
+
+        let event = try #require(
+            NSEvent.mouseEvent(
+                with: .rightMouseUp,
+                location: .init(x: 10, y: 10),
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                eventNumber: 1,
+                clickCount: 1,
+                pressure: 1
+            )
+        )
+
+        let menu = view.menu(for: event)
+        #expect(menu == nil)
+    }
+
+    @Test
     func contextMenuShortcutMappingMatchesTerminalCommands() {
         #expect(TerminalView.shortcut(for: .copy) == TerminalActionShortcut(keyEquivalent: "c", modifierFlags: [.command]))
         #expect(TerminalView.shortcut(for: .paste) == TerminalActionShortcut(keyEquivalent: "v", modifierFlags: [.command]))


### PR DESCRIPTION
#### 变更内容

- 在设置页新增终端行为开关
- 支持启用“选中即复制，右键粘贴”
- 默认关闭，关闭时保持当前终端行为不变
- 打开后：
  - 左键选中后自动复制
  - 右键直接执行粘贴，不再弹出上下文菜单

#### 变更原因

- 原 PR #10 中这部分实现与 `xcodeproj`、`AGENTS.md` 等无关改动混在一起，不适合直接 cherry-pick
- 这里单独拆分，保留设置项控制能力，避免行为变更默认影响所有用户

#### 测试方式

- `swift test --filter AppSettingsTests`
- `swift test --filter TerminalViewTests`
- `swift test --filter L10nTests`
- `swift test`

#### 补充说明

- 已新增 focused tests，覆盖：
  - 设置项持久化
  - 关闭时右键仍显示上下文菜单
  - 开启时右键直接粘贴
