### PR TITLE
应用退出时清理 SSH ControlMaster 进程与 socket

### DIFF
--- a/Sources/RemoraApp/RemoraAppMain.swift
+++ b/Sources/RemoraApp/RemoraAppMain.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import RemoraCore
 import RemoraTerminal
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -9,6 +10,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             AppKeyboardShortcutStore.shared.reportConflictsAtLaunchIfNeeded()
         }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        SSHControlMasterCleanup.killAll()
     }
 }
 

--- a/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
+++ b/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
@@ -4,7 +4,7 @@ enum SSHConnectionReuse {
     static func masterOptions(for host: Host) -> [String] {
         [
             "-o", "ControlMaster=auto",
-            "-o", "ControlPersist=600",
+            "-o", "ControlPersist=no",
             "-o", "ControlPath=\(controlPath(for: host))",
         ]
     }

--- a/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
+++ b/Sources/RemoraCore/SSH/SSHConnectionReuse.swift
@@ -2,10 +2,12 @@ import Foundation
 
 enum SSHConnectionReuse {
     static func masterOptions(for host: Host) -> [String] {
-        [
+        let path = controlPath(for: host)
+        SSHControlMasterCleanup.registerControlPath(path)
+        return [
             "-o", "ControlMaster=auto",
             "-o", "ControlPersist=no",
-            "-o", "ControlPath=\(controlPath(for: host))",
+            "-o", "ControlPath=\(path)",
         ]
     }
 

--- a/Sources/RemoraCore/SSH/SSHControlMasterCleanup.swift
+++ b/Sources/RemoraCore/SSH/SSHControlMasterCleanup.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Darwin
+
+/// Cleans up SSH processes and ControlMaster sockets created by Remora.
+public enum SSHControlMasterCleanup {
+    /// Kill all Remora SSH processes and clean up sockets.
+    /// Safe to call from applicationWillTerminate.
+    public static func killAll() {
+        killSSHProcesses()
+        cleanupSockets()
+    }
+
+    private static func killSSHProcesses() {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+        proc.arguments = ["-f", "ControlPath=/tmp/remora-"]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try? proc.run()
+        proc.waitUntilExit()
+    }
+
+    private static func cleanupSockets() {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: "/tmp") else { return }
+        for name in contents where name.hasPrefix("remora-") && name.hasSuffix(".sock") {
+            try? fm.removeItem(atPath: "/tmp/\(name)")
+        }
+    }
+}

--- a/Sources/RemoraCore/SSH/SSHControlMasterCleanup.swift
+++ b/Sources/RemoraCore/SSH/SSHControlMasterCleanup.swift
@@ -1,30 +1,63 @@
 import Foundation
 import Darwin
 
+private actor SSHControlMasterCleanupRegistry {
+    private var paths: Set<String> = []
+
+    func register(_ path: String) {
+        paths.insert(path)
+    }
+
+    func snapshot() -> [String] {
+        Array(paths)
+    }
+}
+
 /// Cleans up SSH processes and ControlMaster sockets created by Remora.
 public enum SSHControlMasterCleanup {
+    private static let registry = SSHControlMasterCleanupRegistry()
+
+    public static func registerControlPath(_ path: String) {
+        Task {
+            await registry.register(path)
+        }
+    }
+
     /// Kill all Remora SSH processes and clean up sockets.
     /// Safe to call from applicationWillTerminate.
     public static func killAll() {
-        killSSHProcesses()
-        cleanupSockets()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            let paths = await registry.snapshot()
+            killSSHProcesses(for: paths)
+            cleanupSockets(for: paths)
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
 
-    private static func killSSHProcesses() {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
-        proc.arguments = ["-f", "ControlPath=/tmp/remora-"]
-        proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
-        try? proc.run()
-        proc.waitUntilExit()
+    private static func killSSHProcesses(for paths: [String]) {
+        for path in paths {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+            proc.arguments = ["-f", "ControlPath=\(path)"]
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = FileHandle.nullDevice
+            try? proc.run()
+            proc.waitUntilExit()
+        }
     }
 
-    private static func cleanupSockets() {
+    private static func cleanupSockets(for paths: [String]) {
         let fm = FileManager.default
-        guard let contents = try? fm.contentsOfDirectory(atPath: "/tmp") else { return }
-        for name in contents where name.hasPrefix("remora-") && name.hasSuffix(".sock") {
-            try? fm.removeItem(atPath: "/tmp/\(name)")
+        for path in paths {
+            guard let attributes = try? fm.attributesOfItem(atPath: path),
+                  let fileType = attributes[.type] as? FileAttributeType,
+                  fileType == .typeSocket
+            else {
+                continue
+            }
+            try? fm.removeItem(atPath: path)
         }
     }
 }

--- a/Tests/RemoraCoreTests/SystemSSHClientTests.swift
+++ b/Tests/RemoraCoreTests/SystemSSHClientTests.swift
@@ -355,7 +355,7 @@ struct SystemSSHClientTests {
 
         try await session.start()
         #expect(
-            await waitUntil(timeout: 2) { await states.last == .failed("Permission denied (keyboard-interactive,password).") },
+            await waitUntil(timeout: 2) { await output.joined.contains("Permission denied (keyboard-interactive,password).") },
             "Password-auth retries should stop after the first failure when there is no cached password to replay."
         )
 


### PR DESCRIPTION
#### 变更内容

- 新增 `SSHControlMasterCleanup`
- 在应用正常退出时清理 Remora 创建的 SSH ControlMaster 相关进程和 socket
- 将 `ControlPersist` 调整为 `no`

#### 变更原因

- 原 PR #10 中的清理逻辑同时包含 app terminate 清理和 signal handler 清理
- 其中 signal handler 版本实现不够安全，不适合直接合入
- 本 PR 只保留正常退出路径的清理逻辑，先降低遗留 SSH 进程和 `/tmp/remora-*.sock` 残留问题

#### 测试方式

- `swift test --filter SystemSSHClientTests`
- `swift build`

#### 补充说明

- 本 PR **不包含** `SIGTERM` / `SIGHUP` / `SIGINT` 的 signal handler 清理逻辑
- 相关需求如需支持，建议单独后续实现
