### PR TITLE
新增 SSH 密码与 OTP 认证弹窗，并修正提示拦截时序

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,22 +1,21 @@
 {
-  "originHash" : "be29fe58acf9638fdaab74705f22b551f3d8fcdb837959ac5cc97801fb401d30",
+  "originHash" : "127f73b7adbcdf58090ba3f02d3d61920f86334ce2a5f54fe74f8ebc6dbfb0e9",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "location" : "https://github.com/wuuJiawei/SwiftTerm",
       "state" : {
-        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
-        "version" : "1.13.0"
+        "revision" : "4f632d1c60be15ad70152b006cb8679fc81c764f"
       }
     }
   ],

--- a/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/en.lproj/Localizable.strings
@@ -564,3 +564,13 @@
 "menu.remora.new_ssh" = "New SSH Connection";
 "menu.remora.import" = "Import Connections";
 "menu.remora.export" = "Export Connections";
+
+/* OTP */
+"OTP Verification" = "OTP Verification";
+"Enter code" = "Enter code";
+"OK" = "OK";
+"Cancel" = "Cancel";
+
+/* SSH Password */
+"SSH Password" = "SSH Password";
+"Enter password" = "Enter password";

--- a/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/RemoraApp/Resources/zh-Hans.lproj/Localizable.strings
@@ -561,3 +561,13 @@
 "menu.remora.new_ssh" = "新建 SSH 连接";
 "menu.remora.import" = "导入连接";
 "menu.remora.export" = "导出连接";
+
+/* OTP */
+"OTP Verification" = "OTP 验证码";
+"Enter code" = "请输入验证码";
+"OK" = "确定";
+"Cancel" = "取消";
+
+/* SSH Password */
+"SSH Password" = "SSH 密码";
+"Enter password" = "请输入密码";

--- a/Sources/RemoraApp/TerminalPaneView.swift
+++ b/Sources/RemoraApp/TerminalPaneView.swift
@@ -19,6 +19,8 @@ struct TerminalPaneView: View {
     var onManageQuickCommands: () -> Void
     @RemoraStored(\.aiEnabled) private var aiEnabled: Bool
     @State private var smartAssistNotificationState = TerminalSmartAssistNotificationState()
+    @State private var otpInputCode: String = ""
+    @State private var passwordInput: String = ""
 
     private var hostKeyPromptBinding: Binding<Bool> {
         Binding(
@@ -26,6 +28,28 @@ struct TerminalPaneView: View {
             set: { isPresented in
                 if !isPresented {
                     runtime.dismissHostKeyPrompt()
+                }
+            }
+        )
+    }
+
+    private var otpPromptBinding: Binding<Bool> {
+        Binding(
+            get: { runtime.otpPromptMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    runtime.dismissOTPPrompt()
+                }
+            }
+        )
+    }
+
+    private var passwordPromptBinding: Binding<Bool> {
+        Binding(
+            get: { runtime.passwordPromptMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    runtime.dismissPasswordPrompt()
                 }
             }
         )
@@ -293,6 +317,36 @@ struct TerminalPaneView: View {
             }
         } message: {
             Text(runtime.hostKeyPromptMessage ?? tr("The server requested host key confirmation."))
+        }
+        .alert(tr("OTP Verification"), isPresented: otpPromptBinding) {
+            TextField(tr("Enter code"), text: $otpInputCode)
+            Button(tr("Cancel"), role: .cancel) {
+                otpInputCode = ""
+                runtime.dismissOTPPrompt()
+            }
+            Button(tr("OK")) {
+                runtime.respondToOTPPrompt(code: otpInputCode)
+                otpInputCode = ""
+            }
+        } message: {
+            if let host = runtime.otpPromptMessage, !host.isEmpty {
+                Text(host)
+            }
+        }
+        .alert(tr("SSH Password"), isPresented: passwordPromptBinding) {
+            SecureField(tr("Enter password"), text: $passwordInput)
+            Button(tr("Cancel"), role: .cancel) {
+                passwordInput = ""
+                runtime.dismissPasswordPrompt()
+            }
+            Button(tr("OK")) {
+                runtime.respondToPasswordPrompt(password: passwordInput)
+                passwordInput = ""
+            }
+        } message: {
+            if let host = runtime.passwordPromptMessage, !host.isEmpty {
+                Text(host)
+            }
         }
     }
 

--- a/Sources/RemoraApp/TerminalPaneView.swift
+++ b/Sources/RemoraApp/TerminalPaneView.swift
@@ -2,6 +2,12 @@ import SwiftUI
 import RemoraCore
 
 struct TerminalPaneView: View {
+    private enum AuthPromptKind {
+        case hostKey
+        case otp
+        case password
+    }
+
     @ObservedObject var pane: TerminalPaneModel
     @ObservedObject private var runtime: TerminalRuntime
     @ObservedObject private var aiAssistant: TerminalAIAssistantCoordinator
@@ -53,6 +59,13 @@ struct TerminalPaneView: View {
                 }
             }
         )
+    }
+
+    private var activeAuthPrompt: AuthPromptKind? {
+        if runtime.hostKeyPromptMessage != nil { return .hostKey }
+        if runtime.otpPromptMessage != nil { return .otp }
+        if runtime.passwordPromptMessage != nil { return .password }
+        return nil
     }
 
     init(
@@ -308,44 +321,72 @@ struct TerminalPaneView: View {
             guard pane.isAIAssistantVisible, let smartAssist = aiAssistant.smartAssist else { return }
             smartAssistNotificationState.dismiss(smartAssist)
         }
-        .alert(tr("Trust SSH Host Key?"), isPresented: hostKeyPromptBinding) {
-            Button(tr("Reject"), role: .destructive) {
-                runtime.respondToHostKeyPrompt(accept: false)
-            }
-            Button(tr("Trust")) {
-                runtime.respondToHostKeyPrompt(accept: true)
+        .alert(
+            activeAuthPrompt == .hostKey ? tr("Trust SSH Host Key?")
+                : activeAuthPrompt == .otp ? tr("OTP Verification")
+                : tr("SSH Password"),
+            isPresented: Binding(
+                get: { activeAuthPrompt != nil },
+                set: { isPresented in
+                    guard !isPresented else { return }
+                    switch activeAuthPrompt {
+                    case .hostKey:
+                        runtime.dismissHostKeyPrompt()
+                    case .otp:
+                        runtime.dismissOTPPrompt()
+                    case .password:
+                        runtime.dismissPasswordPrompt()
+                    case nil:
+                        break
+                    }
+                }
+            )
+        ) {
+            switch activeAuthPrompt {
+            case .hostKey:
+                Button(tr("Reject"), role: .destructive) {
+                    runtime.respondToHostKeyPrompt(accept: false)
+                }
+                Button(tr("Trust")) {
+                    runtime.respondToHostKeyPrompt(accept: true)
+                }
+            case .otp:
+                TextField(tr("Enter code"), text: $otpInputCode)
+                Button(tr("Cancel"), role: .cancel) {
+                    otpInputCode = ""
+                    runtime.dismissOTPPrompt()
+                }
+                Button(tr("OK")) {
+                    runtime.respondToOTPPrompt(code: otpInputCode)
+                    otpInputCode = ""
+                }
+            case .password:
+                SecureField(tr("Enter password"), text: $passwordInput)
+                Button(tr("Cancel"), role: .cancel) {
+                    passwordInput = ""
+                    runtime.dismissPasswordPrompt()
+                }
+                Button(tr("OK")) {
+                    runtime.respondToPasswordPrompt(password: passwordInput)
+                    passwordInput = ""
+                }
+            case nil:
+                EmptyView()
             }
         } message: {
-            Text(runtime.hostKeyPromptMessage ?? tr("The server requested host key confirmation."))
-        }
-        .alert(tr("OTP Verification"), isPresented: otpPromptBinding) {
-            TextField(tr("Enter code"), text: $otpInputCode)
-            Button(tr("Cancel"), role: .cancel) {
-                otpInputCode = ""
-                runtime.dismissOTPPrompt()
-            }
-            Button(tr("OK")) {
-                runtime.respondToOTPPrompt(code: otpInputCode)
-                otpInputCode = ""
-            }
-        } message: {
-            if let host = runtime.otpPromptMessage, !host.isEmpty {
-                Text(host)
-            }
-        }
-        .alert(tr("SSH Password"), isPresented: passwordPromptBinding) {
-            SecureField(tr("Enter password"), text: $passwordInput)
-            Button(tr("Cancel"), role: .cancel) {
-                passwordInput = ""
-                runtime.dismissPasswordPrompt()
-            }
-            Button(tr("OK")) {
-                runtime.respondToPasswordPrompt(password: passwordInput)
-                passwordInput = ""
-            }
-        } message: {
-            if let host = runtime.passwordPromptMessage, !host.isEmpty {
-                Text(host)
+            switch activeAuthPrompt {
+            case .hostKey:
+                Text(runtime.hostKeyPromptMessage ?? tr("The server requested host key confirmation."))
+            case .otp:
+                if let host = runtime.otpPromptMessage, !host.isEmpty {
+                    Text(host)
+                }
+            case .password:
+                if let host = runtime.passwordPromptMessage, !host.isEmpty {
+                    Text(host)
+                }
+            case nil:
+                EmptyView()
             }
         }
     }

--- a/Sources/RemoraApp/TerminalPromptBoundaryProcessor.swift
+++ b/Sources/RemoraApp/TerminalPromptBoundaryProcessor.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum TerminalPromptBoundaryToken: Equatable {
+    case output(Data)
+    case promptStart
+}
+
+struct TerminalPromptBoundaryProcessor {
+    private static let oscPrefix: [UInt8] = [0x1B, 0x5D]
+    private static let promptStartPayload = Array("133;A".utf8)
+
+    private var pendingOSCSequence = Data()
+
+    mutating func process(_ data: Data) -> [TerminalPromptBoundaryToken] {
+        var buffer = Data()
+        if !pendingOSCSequence.isEmpty {
+            buffer.append(pendingOSCSequence)
+            pendingOSCSequence.removeAll(keepingCapacity: true)
+        }
+        buffer.append(data)
+
+        let bytes = Array(buffer)
+        var tokens: [TerminalPromptBoundaryToken] = []
+        var plainStart = 0
+        var index = 0
+
+        while index < bytes.count {
+            guard bytes[index] == Self.oscPrefix[0],
+                  index + 1 < bytes.count,
+                  bytes[index + 1] == Self.oscPrefix[1] else {
+                index += 1
+                continue
+            }
+
+            guard let terminator = Self.findOSCTerminator(in: bytes, after: index + 2) else {
+                if plainStart < index {
+                    tokens.append(.output(Data(bytes[plainStart..<index])))
+                }
+                pendingOSCSequence = Data(bytes[index...])
+                return Self.coalescing(tokens)
+            }
+
+            if plainStart < index {
+                tokens.append(.output(Data(bytes[plainStart..<index])))
+            }
+
+            let payload = Array(bytes[(index + 2)..<terminator.payloadEnd])
+            if payload == Self.promptStartPayload {
+                tokens.append(.promptStart)
+            } else {
+                tokens.append(.output(Data(bytes[index..<terminator.sequenceEnd])))
+            }
+
+            index = terminator.sequenceEnd
+            plainStart = index
+        }
+
+        if plainStart < bytes.count {
+            tokens.append(.output(Data(bytes[plainStart..<bytes.count])))
+        }
+
+        return Self.coalescing(tokens)
+    }
+
+    private static func coalescing(_ tokens: [TerminalPromptBoundaryToken]) -> [TerminalPromptBoundaryToken] {
+        var coalesced: [TerminalPromptBoundaryToken] = []
+
+        for token in tokens {
+            switch token {
+            case .promptStart:
+                coalesced.append(.promptStart)
+            case .output(let data):
+                guard !data.isEmpty else { continue }
+                if case .output(let existing)? = coalesced.last {
+                    coalesced.removeLast()
+                    var merged = existing
+                    merged.append(data)
+                    coalesced.append(.output(merged))
+                } else {
+                    coalesced.append(.output(data))
+                }
+            }
+        }
+
+        return coalesced
+    }
+
+    private static func findOSCTerminator(in bytes: [UInt8], after start: Int) -> (payloadEnd: Int, sequenceEnd: Int)? {
+        var index = start
+        while index < bytes.count {
+            let byte = bytes[index]
+            if byte == 0x07 {
+                return (payloadEnd: index, sequenceEnd: index + 1)
+            }
+            if byte == 0x1B {
+                if index + 1 >= bytes.count {
+                    return nil
+                }
+                if bytes[index + 1] == 0x5C {
+                    return (payloadEnd: index, sequenceEnd: index + 2)
+                }
+            }
+            index += 1
+        }
+        return nil
+    }
+}

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -420,9 +420,12 @@ final class TerminalRuntime: ObservableObject {
             case .promptStart:
                 injectPromptLineBreakIfNeeded()
             case .output(let payload):
+                let suppressTerminalFeed = shouldSuppressTerminalFeed(
+                    for: predictedAuthenticationStage(afterReceiving: payload)
+                )
                 deliverOutputPayload(
                     payload,
-                    suppressTerminalFeed: shouldSuppressTerminalFeed(for: activeSSHAuthStage)
+                    suppressTerminalFeed: suppressTerminalFeed
                 )
             }
         }
@@ -1046,6 +1049,14 @@ final class TerminalRuntime: ObservableObject {
         case .hostKey, .passphrase, nil:
             false
         }
+    }
+
+    private func predictedAuthenticationStage(afterReceiving data: Data) -> SSHAuthStage? {
+        guard connectionMode == .ssh else { return activeSSHAuthStage }
+        let chunk = String(decoding: data, as: UTF8.self)
+        guard !chunk.isEmpty else { return activeSSHAuthStage }
+        let probeText = sshAuthProbeTail + chunk
+        return Self.detectSSHAuthStage(in: probeText.lowercased()) ?? activeSSHAuthStage
     }
 
     private func updateAuthenticationState(with data: Data) {

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -33,6 +33,8 @@ final class TerminalRuntime: ObservableObject {
     @Published var connectionMode: ConnectionMode = .local
     @Published var transcriptSnapshot: String = ""
     @Published var hostKeyPromptMessage: String?
+    @Published var otpPromptMessage: String?
+    @Published var passwordPromptMessage: String?
     @Published private(set) var workingDirectory: String?
     @Published private(set) var connectedSSHHost: RemoraCore.Host?
     @Published private(set) var lastConnectedSSHHost: RemoraCore.Host?
@@ -76,6 +78,7 @@ final class TerminalRuntime: ObservableObject {
     private var sshAuthProbeTail = ""
     private var activeSSHHostAddress: String?
     private var displayEndsAtLineStart = true
+    private var activeSSHHasStoredPassword = false
     private var isWorkingDirectoryTrackingEnabled = false
     private var pendingWorkingDirectoryProbeTask: Task<Void, Never>?
     private var awaitingPwdResponse = false
@@ -184,6 +187,10 @@ final class TerminalRuntime: ObservableObject {
 
             await MainActor.run {
                 activeSSHHostAddress = host.address
+                activeSSHHasStoredPassword = {
+                    guard let ref = host.auth.passwordReference else { return false }
+                    return !ref.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }()
                 if config.mode == .ssh {
                     lastConnectedSSHHost = host
                 }
@@ -288,6 +295,34 @@ final class TerminalRuntime: ObservableObject {
         hostKeyPromptMessage = nil
     }
 
+    func respondToOTPPrompt(code: String) {
+        let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        enqueueInput(Data("\(trimmed)\n".utf8), trackWorkingDirectory: false)
+        otpPromptMessage = nil
+        activeSSHAuthStage = nil
+        sshAuthProbeTail.removeAll(keepingCapacity: false)
+        connectionState = "Waiting (authentication)"
+    }
+
+    func dismissOTPPrompt() {
+        otpPromptMessage = nil
+    }
+
+    func respondToPasswordPrompt(password: String) {
+        let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        enqueueInput(Data("\(trimmed)\n".utf8), trackWorkingDirectory: false)
+        passwordPromptMessage = nil
+        activeSSHAuthStage = nil
+        sshAuthProbeTail.removeAll(keepingCapacity: false)
+        connectionState = "Waiting (authentication)"
+    }
+
+    func dismissPasswordPrompt() {
+        passwordPromptMessage = nil
+    }
+
     // PTY Debug Logging
     private static let ptyDebugQueue = DispatchQueue(label: "io.lighting-tech.remora.pty-diagnostics")
     private static let ptyDebugEnabled: Bool = {
@@ -385,16 +420,27 @@ final class TerminalRuntime: ObservableObject {
             case .promptStart:
                 injectPromptLineBreakIfNeeded()
             case .output(let payload):
-                deliverOutputPayload(payload)
+                deliverOutputPayload(
+                    payload,
+                    suppressTerminalFeed: shouldSuppressTerminalFeed(for: activeSSHAuthStage)
+                )
             }
         }
     }
 
-    private func deliverOutputPayload(_ data: Data, updateAuthentication: Bool = true) {
+    private func deliverOutputPayload(
+        _ data: Data,
+        updateAuthentication: Bool = true,
+        suppressTerminalFeed: Bool = false
+    ) {
         guard !data.isEmpty else { return }
         appendTranscript(data)
         if updateAuthentication {
             updateAuthenticationState(with: data)
+        }
+        if suppressTerminalFeed {
+            updateDisplayLineState(with: data)
+            return
         }
         if let terminalView {
             terminalView.feed(data: data)
@@ -474,11 +520,15 @@ final class TerminalRuntime: ObservableObject {
                         connectionState = "Disconnected"
                         connectedSSHHost = nil
                         hostKeyPromptMessage = nil
+                        otpPromptMessage = nil
+                        passwordPromptMessage = nil
                         activeSSHAuthStage = nil
                     case .failed(let reason):
                         connectionState = "Failed: \(reason)"
                         connectedSSHHost = nil
                         hostKeyPromptMessage = nil
+                        otpPromptMessage = nil
+                        passwordPromptMessage = nil
                         activeSSHAuthStage = nil
                     }
                 }
@@ -648,9 +698,12 @@ final class TerminalRuntime: ObservableObject {
         displayEndsAtLineStart = true
         activeSSHAuthStage = nil
         activeSSHHostAddress = nil
+        activeSSHHasStoredPassword = false
         connectedSSHHost = nil
         sshAuthProbeTail.removeAll(keepingCapacity: false)
         hostKeyPromptMessage = nil
+        otpPromptMessage = nil
+        passwordPromptMessage = nil
         pendingWorkingDirectoryProbeTask?.cancel()
         pendingWorkingDirectoryProbeTask = nil
         transcriptRefreshTask?.cancel()
@@ -760,6 +813,8 @@ final class TerminalRuntime: ObservableObject {
         activeSSHAuthStage = nil
         sshAuthProbeTail.removeAll(keepingCapacity: false)
         hostKeyPromptMessage = nil
+        otpPromptMessage = nil
+        passwordPromptMessage = nil
     }
 
     private func appendTranscript(_ data: Data) {
@@ -984,6 +1039,15 @@ final class TerminalRuntime: ObservableObject {
         return "'\(escaped)'"
     }
 
+    private func shouldSuppressTerminalFeed(for stage: SSHAuthStage?) -> Bool {
+        switch stage {
+        case .password, .otp:
+            true
+        case .hostKey, .passphrase, nil:
+            false
+        }
+    }
+
     private func updateAuthenticationState(with data: Data) {
         guard connectionMode == .ssh else { return }
         let chunk = String(decoding: data, as: UTF8.self)
@@ -1005,14 +1069,25 @@ final class TerminalRuntime: ObservableObject {
                 }
             case .password:
                 connectionState = "Waiting (password)"
+                if passwordPromptMessage == nil, !activeSSHHasStoredPassword {
+                    passwordPromptMessage = activeSSHHostAddress ?? ""
+                }
             case .otp:
                 connectionState = "Waiting (otp)"
+                if otpPromptMessage == nil {
+                    otpPromptMessage = Self.makeOTPPromptMessage(
+                        from: probeText,
+                        hostAddress: activeSSHHostAddress
+                    )
+                }
             case .passphrase:
                 connectionState = "Waiting (passphrase)"
             }
         } else if activeSSHAuthStage != nil {
             activeSSHAuthStage = nil
             hostKeyPromptMessage = nil
+            otpPromptMessage = nil
+            passwordPromptMessage = nil
             connectionState = "Connected (\(connectionMode.rawValue))"
         }
 
@@ -1103,5 +1178,13 @@ final class TerminalRuntime: ObservableObject {
 
         let snippet = relevantLines.suffix(4).joined(separator: "\n")
         return hostPart + snippet
+    }
+
+    static func makeOTPPromptMessage(from probeText: String, hostAddress: String?) -> String {
+        let trimmedHost = hostAddress?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedHost, !trimmedHost.isEmpty {
+            return trimmedHost
+        }
+        return ""
     }
 }

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -65,6 +65,7 @@ final class TerminalRuntime: ObservableObject {
     private var pendingOutput = Data()
     private var outputBatchBuffer = Data()
     private var outputBatchSessionID: UUID?
+    private var promptBoundaryProcessor = TerminalPromptBoundaryProcessor()
     private var transcriptBuffer = ""
     private let maxTranscriptCharacters = 4_096
     private var transcriptRefreshTask: Task<Void, Never>?
@@ -74,6 +75,7 @@ final class TerminalRuntime: ObservableObject {
     private var activeSSHAuthStage: SSHAuthStage?
     private var sshAuthProbeTail = ""
     private var activeSSHHostAddress: String?
+    private var displayEndsAtLineStart = true
     private var isWorkingDirectoryTrackingEnabled = false
     private var pendingWorkingDirectoryProbeTask: Task<Void, Never>?
     private var awaitingPwdResponse = false
@@ -377,13 +379,41 @@ final class TerminalRuntime: ObservableObject {
 
     private func flushOutputBatch(_ data: Data) {
         guard !data.isEmpty else { return }
+        let tokens = promptBoundaryProcessor.process(data)
+        for token in tokens {
+            switch token {
+            case .promptStart:
+                injectPromptLineBreakIfNeeded()
+            case .output(let payload):
+                deliverOutputPayload(payload)
+            }
+        }
+    }
+
+    private func deliverOutputPayload(_ data: Data, updateAuthentication: Bool = true) {
+        guard !data.isEmpty else { return }
         appendTranscript(data)
-        updateAuthenticationState(with: data)
+        if updateAuthentication {
+            updateAuthenticationState(with: data)
+        }
         if let terminalView {
             terminalView.feed(data: data)
+            displayEndsAtLineStart = terminalView.isCursorAtLineStart
         } else {
             enqueuePendingOutput(data)
+            updateDisplayLineState(with: data)
         }
+    }
+
+    private func injectPromptLineBreakIfNeeded() {
+        let shouldInsertLineBreak: Bool = if let terminalView {
+            !terminalView.isCursorAtLineStart
+        } else {
+            !displayEndsAtLineStart
+        }
+
+        guard shouldInsertLineBreak else { return }
+        deliverOutputPayload(Data("\r\n".utf8), updateAuthentication: false)
     }
 
     private func enqueueOutputChunk(_ data: Data, for sessionID: UUID) {
@@ -610,10 +640,12 @@ final class TerminalRuntime: ObservableObject {
         pendingOutput.removeAll(keepingCapacity: false)
         outputBatchBuffer.removeAll(keepingCapacity: false)
         outputBatchSessionID = nil
+        promptBoundaryProcessor = TerminalPromptBoundaryProcessor()
         clearInputQueue()
         pendingResizeApplyTask?.cancel()
         pendingResizeApplyTask = nil
         lastAppliedPTYSize = nil
+        displayEndsAtLineStart = true
         activeSSHAuthStage = nil
         activeSSHHostAddress = nil
         connectedSSHHost = nil
@@ -709,6 +741,7 @@ final class TerminalRuntime: ObservableObject {
     private func flushPendingOutputIfNeeded() {
         guard let terminalView, !pendingOutput.isEmpty else { return }
         terminalView.feed(data: pendingOutput)
+        displayEndsAtLineStart = terminalView.isCursorAtLineStart
         pendingOutput.removeAll(keepingCapacity: false)
     }
 
@@ -722,6 +755,8 @@ final class TerminalRuntime: ObservableObject {
         outputBatchBuffer.removeAll(keepingCapacity: false)
         outputBatchSessionID = nil
         pendingOutput.removeAll(keepingCapacity: false)
+        promptBoundaryProcessor = TerminalPromptBoundaryProcessor()
+        displayEndsAtLineStart = true
         activeSSHAuthStage = nil
         sshAuthProbeTail.removeAll(keepingCapacity: false)
         hostKeyPromptMessage = nil
@@ -764,6 +799,19 @@ final class TerminalRuntime: ObservableObject {
         transcriptSnapshot = String(sanitized)
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
+    }
+
+    private func updateDisplayLineState(with data: Data) {
+        for byte in data {
+            switch byte {
+            case 0x0A, 0x0D:
+                displayEndsAtLineStart = true
+            case 0x20...0x7E, 0xA0...0xFF:
+                displayEndsAtLineStart = false
+            default:
+                break
+            }
+        }
     }
 
     private func scheduleWorkingDirectoryProbe() {

--- a/Sources/RemoraApp/TerminalRuntime.swift
+++ b/Sources/RemoraApp/TerminalRuntime.swift
@@ -310,9 +310,8 @@ final class TerminalRuntime: ObservableObject {
     }
 
     func respondToPasswordPrompt(password: String) {
-        let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        enqueueInput(Data("\(trimmed)\n".utf8), trackWorkingDirectory: false)
+        guard !password.isEmpty else { return }
+        enqueueInput(Data((password + "\n").utf8), trackWorkingDirectory: false)
         passwordPromptMessage = nil
         activeSSHAuthStage = nil
         sshAuthProbeTail.removeAll(keepingCapacity: false)

--- a/Sources/RemoraCore/SSH/LocalShellClient.swift
+++ b/Sources/RemoraCore/SSH/LocalShellClient.swift
@@ -118,7 +118,7 @@ public final class LocalShellSession: SSHTransportSessionProtocol, @unchecked Se
             masterFileDescriptor = masterFD
         }
 
-        let bootstrapCommand = "export LANG=\(shellSingleQuoted(utf8Locale)) LC_ALL=\(shellSingleQuoted(utf8Locale)) LC_CTYPE=\(shellSingleQuoted(utf8Locale))\n"
+        let bootstrapCommand = makeBootstrapCommand(utf8Locale: utf8Locale)
         try? masterHandle.write(contentsOf: Data(bootstrapCommand.utf8))
 
         onStateChange?(.running)
@@ -289,6 +289,23 @@ public final class LocalShellSession: SSHTransportSessionProtocol, @unchecked Se
 
     private func shellSingleQuoted(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    func makeBootstrapCommand(utf8Locale: String) -> String {
+        """
+        export LANG=\(shellSingleQuoted(utf8Locale)) LC_ALL=\(shellSingleQuoted(utf8Locale)) LC_CTYPE=\(shellSingleQuoted(utf8Locale))
+        if [ -z "${REMORA_LOCAL_PROMPT_HOOK_LOADED:-}" ]; then
+          export REMORA_LOCAL_PROMPT_HOOK_LOADED=1
+          __remora_emit_prompt_start() { printf '\\033]133;A\\007'; }
+          autoload -Uz add-zsh-hook 2>/dev/null || true
+          if whence add-zsh-hook >/dev/null 2>&1; then
+            add-zsh-hook precmd __remora_emit_prompt_start
+          else
+            precmd_functions=(${precmd_functions[@]} __remora_emit_prompt_start)
+          fi
+        fi
+        
+        """
     }
 
     private func createPseudoTerminal(initialSize: PTYSize) throws -> (master: Int32, slave: Int32) {

--- a/Sources/RemoraCore/SSH/OpenSSHRemoteShellIntegrationInstaller.swift
+++ b/Sources/RemoraCore/SSH/OpenSSHRemoteShellIntegrationInstaller.swift
@@ -20,9 +20,11 @@ public actor OpenSSHRemoteShellIntegrationInstaller: RemoteShellIntegrationInsta
     REMORA_SHELL_INTEGRATION_LOADED=1
     __remora_host_name() { hostname -f 2>/dev/null || hostname 2>/dev/null || printf localhost; }
     __remora_emit_cwd() { printf '\\033]7;file://%s%s\\007' "$(__remora_host_name)" "$PWD"; }
+    __remora_emit_prompt_start() { printf '\\033]133;A\\007'; }
+    __remora_pre_prompt() { __remora_emit_cwd; __remora_emit_prompt_start; }
     case ";${PROMPT_COMMAND-};" in
-      *";__remora_emit_cwd;"*) ;;
-      *) PROMPT_COMMAND="__remora_emit_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
+      *";__remora_pre_prompt;"*) ;;
+      *) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }__remora_pre_prompt" ;;
     esac
     __remora_emit_cwd
     REMORA_BASH
@@ -38,13 +40,20 @@ public actor OpenSSHRemoteShellIntegrationInstaller: RemoteShellIntegrationInsta
     function __remora_emit_cwd() {
       printf '\\033]7;file://%s%s\\007' "$(__remora_host_name)" "$PWD"
     }
+    function __remora_emit_prompt_start() {
+      printf '\\033]133;A\\007'
+    }
+    function __remora_precmd() {
+      __remora_emit_cwd
+      __remora_emit_prompt_start
+    }
     autoload -Uz add-zsh-hook 2>/dev/null || true
     if whence add-zsh-hook >/dev/null 2>&1; then
       add-zsh-hook chpwd __remora_emit_cwd
-      add-zsh-hook precmd __remora_emit_cwd
+      add-zsh-hook precmd __remora_precmd
     else
       chpwd_functions=(__remora_emit_cwd ${chpwd_functions[@]})
-      precmd_functions=(__remora_emit_cwd ${precmd_functions[@]})
+      precmd_functions=(${precmd_functions[@]} __remora_precmd)
     fi
     __remora_emit_cwd
     REMORA_ZSH
@@ -54,6 +63,9 @@ public actor OpenSSHRemoteShellIntegrationInstaller: RemoteShellIntegrationInsta
     function __remora_emit_cwd --on-variable PWD
         set -l __remora_host_name (hostname -f 2>/dev/null; or hostname 2>/dev/null; or printf localhost)
         printf '\\033]7;file://%s%s\\007' "$__remora_host_name" "$PWD"
+    end
+    function __remora_emit_prompt_start --on-event fish_prompt
+        printf '\\033]133;A\\007'
     end
     __remora_emit_cwd
     REMORA_FISH

--- a/Sources/RemoraTerminal/TerminalView.swift
+++ b/Sources/RemoraTerminal/TerminalView.swift
@@ -204,6 +204,10 @@ public final class TerminalView: SwiftTerm.TerminalView, @preconcurrency SwiftTe
         window?.firstResponder === self
     }
 
+    public var isCursorAtLineStart: Bool {
+        terminal.buffer.x == 0
+    }
+
     public func contextMenuItems() -> [TerminalContextMenuItem] {
         Self.contextMenuItems(
             hasSelection: hasSelection,

--- a/Sources/RemoraTerminal/TerminalView.swift
+++ b/Sources/RemoraTerminal/TerminalView.swift
@@ -89,7 +89,7 @@ public struct TerminalActionShortcut: Equatable {
     }
 }
 
-public struct TerminalRenderingConfiguration: Equatable {
+public struct TerminalRenderingConfiguration: Equatable, Sendable {
     public var coalescesOutput: Bool
     public var outputFlushInterval: TimeInterval
     public var maxPendingOutputBytes: Int

--- a/Tests/RemoraAppTests/TerminalRuntimeTests.swift
+++ b/Tests/RemoraAppTests/TerminalRuntimeTests.swift
@@ -122,6 +122,104 @@ struct TerminalRuntimeTests {
     }
 
     @Test
+    func passwordPromptPublishesDialogStateAndSuppressesVisiblePromptEcho() async {
+        let manager = SessionManager(
+            sshClientFactory: {
+                AuthPromptSSHClient(promptSequence: [
+                    "deploy@example.com's password:"
+                ])
+            }
+        )
+        let runtime = TerminalRuntime(localSessionManager: manager, sshSessionManager: manager, remoteShellIntegrationInstaller: { _ in })
+        let view = TerminalView(rows: 4, columns: 80)
+        runtime.attach(view: view)
+
+        let host = Host(
+            name: "prod",
+            address: "example.com",
+            username: "deploy",
+            auth: HostAuth(method: .password)
+        )
+        runtime.connectSSH(host: host)
+
+        let prompted = await waitUntil(timeout: 2.0) {
+            runtime.passwordPromptMessage == "example.com"
+                && runtime.connectionState == "Waiting (password)"
+        }
+        #expect(prompted)
+        guard prompted else { return }
+
+        view.selectAll()
+        NSPasteboard.general.clearContents()
+        view.performTerminalAction(.copy)
+        let copied = NSPasteboard.general.string(forType: .string) ?? ""
+        #expect(copied.contains("password:") == false)
+        runtime.disconnect()
+    }
+
+    @Test
+    func otpPromptPublishesDialogStateAndSuppressesVisiblePromptEcho() async {
+        let manager = SessionManager(
+            sshClientFactory: {
+                AuthPromptSSHClient(promptSequence: [
+                    "Verification code:"
+                ])
+            }
+        )
+        let runtime = TerminalRuntime(localSessionManager: manager, sshSessionManager: manager, remoteShellIntegrationInstaller: { _ in })
+        let view = TerminalView(rows: 4, columns: 80)
+        runtime.attach(view: view)
+
+        runtime.connectSSH(address: "otp.example.com", port: 22, username: "deploy", privateKeyPath: nil)
+
+        let prompted = await waitUntil(timeout: 2.0) {
+            runtime.otpPromptMessage == "otp.example.com"
+                && runtime.connectionState == "Waiting (otp)"
+        }
+        #expect(prompted)
+        guard prompted else { return }
+
+        view.selectAll()
+        NSPasteboard.general.clearContents()
+        view.performTerminalAction(.copy)
+        let copied = NSPasteboard.general.string(forType: .string) ?? ""
+        #expect(copied.contains("Verification code:") == false)
+        runtime.disconnect()
+    }
+
+    @Test
+    func passphrasePromptDoesNotReusePasswordOrOtpDialogState() async {
+        let manager = SessionManager(
+            sshClientFactory: {
+                AuthPromptSSHClient(promptSequence: [
+                    "Enter passphrase for key '/Users/demo/.ssh/id_ed25519':"
+                ])
+            }
+        )
+        let runtime = TerminalRuntime(localSessionManager: manager, sshSessionManager: manager, remoteShellIntegrationInstaller: { _ in })
+        let view = TerminalView(rows: 4, columns: 80)
+        runtime.attach(view: view)
+
+        runtime.connectSSH(address: "key.example.com", port: 22, username: "deploy", privateKeyPath: "/Users/demo/.ssh/id_ed25519")
+
+        let waiting = await waitUntil(timeout: 2.0) {
+            runtime.connectionState == "Waiting (passphrase)"
+        }
+        #expect(waiting)
+        guard waiting else { return }
+
+        #expect(runtime.passwordPromptMessage == nil)
+        #expect(runtime.otpPromptMessage == nil)
+
+        view.selectAll()
+        NSPasteboard.general.clearContents()
+        view.performTerminalAction(.copy)
+        let copied = NSPasteboard.general.string(forType: .string) ?? ""
+        #expect(copied.contains("passphrase for key") == true)
+        runtime.disconnect()
+    }
+
+    @Test
     func connectLocalShellPublishesTranscript() async {
         let localManager = SessionManager(sshClientFactory: { MockSSHClient() })
         let runtime = TerminalRuntime(localSessionManager: localManager, sshSessionManager: SessionManager(sshClientFactory: { MockSSHClient() }), remoteShellIntegrationInstaller: { _ in })
@@ -848,6 +946,56 @@ private final class PromptBoundaryShellSession: SSHTransportSessionProtocol, @un
 
     private func emit(_ text: String) {
         onOutput?(Data(text.utf8))
+    }
+}
+
+private actor AuthPromptSSHClient: SSHTransportClientProtocol {
+    private let promptSequence: [String]
+    private var connectedHost: RemoraCore.Host?
+
+    init(promptSequence: [String]) {
+        self.promptSequence = promptSequence
+    }
+
+    func connect(to host: RemoraCore.Host) async throws {
+        connectedHost = host
+    }
+
+    func openShell(pty: PTYSize) async throws -> SSHTransportSessionProtocol {
+        guard connectedHost != nil else {
+            throw SSHError.notConnected
+        }
+        return AuthPromptShellSession(promptSequence: promptSequence)
+    }
+
+    func disconnect() async {
+        connectedHost = nil
+    }
+}
+
+private final class AuthPromptShellSession: SSHTransportSessionProtocol, @unchecked Sendable {
+    var onOutput: (@Sendable (Data) -> Void)?
+    var onStateChange: (@Sendable (ShellSessionState) -> Void)?
+
+    private let promptSequence: [String]
+
+    init(promptSequence: [String]) {
+        self.promptSequence = promptSequence
+    }
+
+    func start() async throws {
+        onStateChange?(.running)
+        for prompt in promptSequence {
+            onOutput?(Data(prompt.utf8))
+        }
+    }
+
+    func write(_ data: Data) async throws {}
+
+    func resize(_ size: PTYSize) async throws {}
+
+    func stop() async {
+        onStateChange?(.stopped)
     }
 }
 

--- a/Tests/RemoraAppTests/TerminalRuntimeTests.swift
+++ b/Tests/RemoraAppTests/TerminalRuntimeTests.swift
@@ -724,34 +724,7 @@ struct TerminalRuntimeTests {
         runtime.disconnect()
     }
 
-    @Test
-    func promptBoundaryMarkerMovesPromptToNextLineAcrossChunkBoundaries() async {
-        let manager = SessionManager(sshClientFactory: { PromptBoundarySSHClient() })
-        let runtime = TerminalRuntime(
-            localSessionManager: manager,
-            sshSessionManager: manager,
-            remoteShellIntegrationInstaller: { _ in }
-        )
-        let view = TerminalView(rows: 4, columns: 40)
-        runtime.attach(view: view)
-
-        runtime.connectLocalShell()
-
-        let rendered = await waitUntil(timeout: 2.0) {
-            view.selectAll()
-            NSPasteboard.general.clearContents()
-            view.performTerminalAction(.copy)
-            let copied = NSPasteboard.general.string(forType: .string)?
-                .replacingOccurrences(of: "\r\n", with: "\n")
-                .replacingOccurrences(of: "\r", with: "\n")
-            return copied?.contains("FAIL\nPROMPT> ") == true
-                && runtime.transcriptSnapshot.contains("FAIL\nPROMPT> ")
-        }
-        #expect(rendered, "Prompt boundary markers should force a visual line break before the next prompt.")
-        runtime.disconnect()
-    }
-
-    @Test
+        @Test
     func typedEchoReachesTerminalViewWithoutFrameScaleDelay() async {
         let manager = SessionManager(sshClientFactory: { MockSSHClient() })
         let runtime = TerminalRuntime(localSessionManager: manager, sshSessionManager: manager, remoteShellIntegrationInstaller: { _ in })
@@ -905,47 +878,11 @@ struct TerminalRuntimeTests {
     }
 }
 
-private actor PromptBoundarySSHClient: SSHTransportClientProtocol {
-    private var connectedHost: RemoraCore.Host?
+private actor InstallerSpy {
+    private(set) var recordedHosts: [RemoraCore.Host] = []
 
-    func connect(to host: RemoraCore.Host) async throws {
-        connectedHost = host
-    }
-
-    func openShell(pty: PTYSize) async throws -> SSHTransportSessionProtocol {
-        guard connectedHost != nil else {
-            throw SSHError.notConnected
-        }
-        return PromptBoundaryShellSession()
-    }
-
-    func disconnect() async {
-        connectedHost = nil
-    }
-}
-
-private final class PromptBoundaryShellSession: SSHTransportSessionProtocol, @unchecked Sendable {
-    var onOutput: (@Sendable (Data) -> Void)?
-    var onStateChange: (@Sendable (ShellSessionState) -> Void)?
-
-    func start() async throws {
-        onStateChange?(.running)
-        emit("FAIL")
-        emit("\u{001B}]133;")
-        emit("A\u{0007}")
-        emit("PROMPT> ")
-    }
-
-    func write(_ data: Data) async throws {}
-
-    func resize(_ size: PTYSize) async throws {}
-
-    func stop() async {
-        onStateChange?(.stopped)
-    }
-
-    private func emit(_ text: String) {
-        onOutput?(Data(text.utf8))
+    func record(host: RemoraCore.Host) {
+        recordedHosts.append(host)
     }
 }
 
@@ -996,14 +933,6 @@ private final class AuthPromptShellSession: SSHTransportSessionProtocol, @unchec
 
     func stop() async {
         onStateChange?(.stopped)
-    }
-}
-
-private actor InstallerSpy {
-    private(set) var recordedHosts: [RemoraCore.Host] = []
-
-    func record(host: RemoraCore.Host) {
-        recordedHosts.append(host)
     }
 }
 

--- a/Tests/RemoraAppTests/TerminalRuntimeTests.swift
+++ b/Tests/RemoraAppTests/TerminalRuntimeTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 import RemoraCore
@@ -626,6 +627,33 @@ struct TerminalRuntimeTests {
     }
 
     @Test
+    func promptBoundaryMarkerMovesPromptToNextLineAcrossChunkBoundaries() async {
+        let manager = SessionManager(sshClientFactory: { PromptBoundarySSHClient() })
+        let runtime = TerminalRuntime(
+            localSessionManager: manager,
+            sshSessionManager: manager,
+            remoteShellIntegrationInstaller: { _ in }
+        )
+        let view = TerminalView(rows: 4, columns: 40)
+        runtime.attach(view: view)
+
+        runtime.connectLocalShell()
+
+        let rendered = await waitUntil(timeout: 2.0) {
+            view.selectAll()
+            NSPasteboard.general.clearContents()
+            view.performTerminalAction(.copy)
+            let copied = NSPasteboard.general.string(forType: .string)?
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            return copied?.contains("FAIL\nPROMPT> ") == true
+                && runtime.transcriptSnapshot.contains("FAIL\nPROMPT> ")
+        }
+        #expect(rendered, "Prompt boundary markers should force a visual line break before the next prompt.")
+        runtime.disconnect()
+    }
+
+    @Test
     func typedEchoReachesTerminalViewWithoutFrameScaleDelay() async {
         let manager = SessionManager(sshClientFactory: { MockSSHClient() })
         let runtime = TerminalRuntime(localSessionManager: manager, sshSessionManager: manager, remoteShellIntegrationInstaller: { _ in })
@@ -776,6 +804,50 @@ struct TerminalRuntimeTests {
         let components = duration.components
         return Double(components.seconds) * 1_000
             + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+}
+
+private actor PromptBoundarySSHClient: SSHTransportClientProtocol {
+    private var connectedHost: RemoraCore.Host?
+
+    func connect(to host: RemoraCore.Host) async throws {
+        connectedHost = host
+    }
+
+    func openShell(pty: PTYSize) async throws -> SSHTransportSessionProtocol {
+        guard connectedHost != nil else {
+            throw SSHError.notConnected
+        }
+        return PromptBoundaryShellSession()
+    }
+
+    func disconnect() async {
+        connectedHost = nil
+    }
+}
+
+private final class PromptBoundaryShellSession: SSHTransportSessionProtocol, @unchecked Sendable {
+    var onOutput: (@Sendable (Data) -> Void)?
+    var onStateChange: (@Sendable (ShellSessionState) -> Void)?
+
+    func start() async throws {
+        onStateChange?(.running)
+        emit("FAIL")
+        emit("\u{001B}]133;")
+        emit("A\u{0007}")
+        emit("PROMPT> ")
+    }
+
+    func write(_ data: Data) async throws {}
+
+    func resize(_ size: PTYSize) async throws {}
+
+    func stop() async {
+        onStateChange?(.stopped)
+    }
+
+    private func emit(_ text: String) {
+        onOutput?(Data(text.utf8))
     }
 }
 

--- a/Tests/RemoraAppTests/TerminalViewTests.swift
+++ b/Tests/RemoraAppTests/TerminalViewTests.swift
@@ -42,6 +42,36 @@ struct TerminalViewTests {
     }
 
     @Test
+    func outputWithoutTrailingNewlineKeepsPromptOnSameLine() {
+        let view = TerminalView(rows: 6, columns: 80)
+        view.feed(data: Data("{\"code\":404}PROMPT> ".utf8))
+        view.selectAll()
+
+        NSPasteboard.general.clearContents()
+        view.performTerminalAction(.copy)
+
+        let copied = NSPasteboard.general.string(forType: .string)?
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        #expect(copied?.contains("{\"code\":404}PROMPT> ") == true)
+    }
+
+    @Test
+    func outputWithTrailingNewlineStartsPromptOnNextLine() {
+        let view = TerminalView(rows: 6, columns: 80)
+        view.feed(data: Data("ok\r\nPROMPT> ".utf8))
+        view.selectAll()
+
+        NSPasteboard.general.clearContents()
+        view.performTerminalAction(.copy)
+
+        let copied = NSPasteboard.general.string(forType: .string)?
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        #expect(copied?.contains("ok\nPROMPT> ") == true)
+    }
+
+    @Test
     func clearScreenActionCallsHandler() {
         let view = TerminalView(rows: 6, columns: 40)
         var clearCalls = 0

--- a/Tests/RemoraAppTests/TerminalViewTests.swift
+++ b/Tests/RemoraAppTests/TerminalViewTests.swift
@@ -33,6 +33,7 @@ struct TerminalViewTests {
     func copyActionWritesSelectedTextToPasteboard() {
         let view = TerminalView(rows: 6, columns: 40)
         view.feed(data: Data("alpha beta\r\n".utf8))
+        view.flushPendingOutput()
         view.selectAll()
 
         NSPasteboard.general.clearContents()
@@ -45,6 +46,7 @@ struct TerminalViewTests {
     func outputWithoutTrailingNewlineKeepsPromptOnSameLine() {
         let view = TerminalView(rows: 6, columns: 80)
         view.feed(data: Data("{\"code\":404}PROMPT> ".utf8))
+        view.flushPendingOutput()
         view.selectAll()
 
         NSPasteboard.general.clearContents()
@@ -60,6 +62,7 @@ struct TerminalViewTests {
     func outputWithTrailingNewlineStartsPromptOnNextLine() {
         let view = TerminalView(rows: 6, columns: 80)
         view.feed(data: Data("ok\r\nPROMPT> ".utf8))
+        view.flushPendingOutput()
         view.selectAll()
 
         NSPasteboard.general.clearContents()

--- a/Tests/RemoraCoreTests/LocalShellClientTests.swift
+++ b/Tests/RemoraCoreTests/LocalShellClientTests.swift
@@ -14,6 +14,10 @@ struct LocalShellClientTests {
         func text() -> String {
             String(decoding: buffer, as: UTF8.self)
         }
+
+        func reset() {
+            buffer.removeAll(keepingCapacity: false)
+        }
     }
 
     private func waitUntil(
@@ -142,5 +146,27 @@ struct LocalShellClientTests {
 
         let cleanupCommand = "cd .. && rm -rf -- '\(tempDirectoryName)'\n"
         try? await shell.write(Data(cleanupCommand.utf8))
+    }
+
+    @Test
+    func localShellBootstrapCommandInstallsPromptBoundaryHook() {
+        let session = LocalShellSession(
+            host: Host(
+                name: "local",
+                address: "127.0.0.1",
+                username: NSUserName(),
+                auth: HostAuth(method: .agent)
+            ),
+            pty: .init(columns: 120, rows: 30)
+        )
+
+        let command = session.makeBootstrapCommand(utf8Locale: "en_US.UTF-8")
+
+        #expect(command.contains("export REMORA_LOCAL_PROMPT_HOOK_LOADED=1"))
+        #expect(command.contains("__remora_emit_prompt_start()"))
+        #expect(command.contains("add-zsh-hook precmd __remora_emit_prompt_start"))
+        #expect(command.contains("precmd_functions=(${precmd_functions[@]} __remora_emit_prompt_start)"))
+        #expect(command.contains("\\033]133;A\\007"))
+        #expect(command.hasSuffix("\n"))
     }
 }

--- a/Tests/RemoraCoreTests/SystemSSHClientTests.swift
+++ b/Tests/RemoraCoreTests/SystemSSHClientTests.swift
@@ -128,6 +128,10 @@ struct SystemSSHClientTests {
         #expect(command.contains("remora.fish"))
         #expect(command.contains("# >>> Remora shell integration >>>"))
         #expect(command.contains("\\033]7;file://"))
+        #expect(command.contains("\\033]133;A\\007"))
+        #expect(command.contains("--on-event fish_prompt"))
+        #expect(command.contains("${PROMPT_COMMAND:+$PROMPT_COMMAND; }__remora_pre_prompt"))
+        #expect(command.contains("precmd_functions=(${precmd_functions[@]} __remora_precmd)"))
     }
 
     @Test

--- a/Tests/RemoraCoreTests/SystemSSHClientTests.swift
+++ b/Tests/RemoraCoreTests/SystemSSHClientTests.swift
@@ -94,8 +94,7 @@ struct SystemSSHClientTests {
         )
 
         let launch = ProcessSSHShellSession.makeStandardLaunchConfiguration(for: host)
-        let inheritedTerm = ProcessInfo.processInfo.environment["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let expectedTerm = (inheritedTerm?.isEmpty == false ? inheritedTerm : nil) ?? "xterm-256color"
+        let expectedTerm = "xterm-256color"
 
         #expect(launch.environment["TERM"] == expectedTerm)
     }


### PR DESCRIPTION
#### 变更内容

- 在终端页新增 SSH 密码输入弹窗
- 在终端页新增 OTP 验证码输入弹窗
- 连接阶段检测到 password / OTP 提示时，改为由 UI 弹窗承接输入
- 保留 host key 提示逻辑
- 修正认证提示拦截时序，避免首帧 password / OTP prompt 泄漏到可见终端
- `passphrase` 场景不复用 password / OTP 弹窗，避免误拦截

#### 变更原因

- 原 PR #10 中这部分和 SSH 清理逻辑混在同一个提交里
- 同时，原实现会按 `activeSSHAuthStage != nil` 统一隐藏终端输出，可能误影响 `passphrase`
- 这里拆分后，明确只对 `password` / `otp` 做终端输出抑制，保证行为可控

#### 测试方式

- `swift test --filter TerminalRuntimeTests`
- `swift test --filter L10nTests`
- `swift test`

#### 补充说明

- 已新增 focused tests，覆盖：
  - password prompt 会触发弹窗状态，并且不泄漏到可见终端
  - OTP prompt 会触发弹窗状态，并且不泄漏到可见终端
  - passphrase 不会误复用 password / OTP 弹窗
