### PR TITLE
修复主线公共构建与测试基线问题

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be29fe58acf9638fdaab74705f22b551f3d8fcdb837959ac5cc97801fb401d30",
+  "originHash" : "127f73b7adbcdf58090ba3f02d3d61920f86334ce2a5f54fe74f8ebc6dbfb0e9",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -13,10 +13,9 @@
     {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "location" : "https://github.com/wuuJiawei/SwiftTerm",
       "state" : {
-        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
-        "version" : "1.13.0"
+        "revision" : "4f632d1c60be15ad70152b006cb8679fc81c764f"
       }
     }
   ],

--- a/Sources/RemoraTerminal/TerminalView.swift
+++ b/Sources/RemoraTerminal/TerminalView.swift
@@ -89,7 +89,7 @@ public struct TerminalActionShortcut: Equatable {
     }
 }
 
-public struct TerminalRenderingConfiguration: Equatable {
+public struct TerminalRenderingConfiguration: Equatable, Sendable {
     public var coalescesOutput: Bool
     public var outputFlushInterval: TimeInterval
     public var maxPendingOutputBytes: Int

--- a/Tests/RemoraAppTests/TerminalViewTests.swift
+++ b/Tests/RemoraAppTests/TerminalViewTests.swift
@@ -33,6 +33,7 @@ struct TerminalViewTests {
     func copyActionWritesSelectedTextToPasteboard() {
         let view = TerminalView(rows: 6, columns: 40)
         view.feed(data: Data("alpha beta\r\n".utf8))
+        view.flushPendingOutput()
         view.selectAll()
 
         NSPasteboard.general.clearContents()

--- a/Tests/RemoraCoreTests/SystemSSHClientTests.swift
+++ b/Tests/RemoraCoreTests/SystemSSHClientTests.swift
@@ -94,8 +94,7 @@ struct SystemSSHClientTests {
         )
 
         let launch = ProcessSSHShellSession.makeStandardLaunchConfiguration(for: host)
-        let inheritedTerm = ProcessInfo.processInfo.environment["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let expectedTerm = (inheritedTerm?.isEmpty == false ? inheritedTerm : nil) ?? "xterm-256color"
+        let expectedTerm = "xterm-256color"
 
         #expect(launch.environment["TERM"] == expectedTerm)
     }


### PR DESCRIPTION
#### 变更内容

- 为 `TerminalRenderingConfiguration` 补充 `Sendable`
- 同步 `SystemSSHClientTests` 对默认 `TERM` 的期望值
- 同步 `TerminalViewTests` 在输出 coalescing 模式下的断言方式
- 更新 `Package.resolved`

#### 变更原因

- 当前主线在 GitHub Actions 的 Swift 6.2 / Xcode 26.3 环境下会触发并发安全检查，导致 `Build and test` 失败
- 同时，终端输出 coalescing 行为已经进入主线，但部分测试仍按旧的立即渲染模型断言，造成 CI 不稳定或直接失败
- 这些问题与 PR #10 的功能拆分无关，属于主线公共基线问题，适合先单独修复

#### 测试方式

- `swift test --filter SystemSSHClientTests`
- `swift test --filter TerminalViewTests`
- `swift test`
